### PR TITLE
fix: use raw test dataset when creating cleaned datasets for the test split

### DIFF
--- a/propra_webscience_ws24/data/data_cleaning.py
+++ b/propra_webscience_ws24/data/data_cleaning.py
@@ -58,7 +58,11 @@ def _get_or_create_cleaned_tweet_data(
     else:
         logger.info(f"Cleaning {split} tweets...")
         dataframe_created = True
-        df_cleaned = pd.read_parquet(constants.TRAIN_DATASET_FILE_PATH)
+        df_cleaned = pd.read_parquet(
+            constants.TRAIN_DATASET_FILE_PATH
+            if split == "train"
+            else constants.TEST_DATASET_FILE_PATH
+        )
         df_cleaned["cleaned_text"] = df_cleaned[text_column].apply(_sanitize_tweets)
         df_cleaned.to_parquet(cleaned_df_file_path)
 


### PR DESCRIPTION
Wir hatten für einzelne Modelle deutlich erhöhte accuracy Werte für die Test-Daten festgestellt.

Die Ursache war ein Fehler bei der Erstellung des Testdatensatzes. 
Hier wurde fälschlicherweise immer der Trainingsdatensatz verwendet um den bereinigten Datensatz zu erzeugen. Dadurch enthielten auch die unterschiedlichen vorverarbeiteten Testdatensätze die eigentlichen Trainingsdaten und dementsprechend waren unsere accuracy Werte für die Testdatensätze eigentlich accuracy Werte für die Trainingsdaten des trainierten Modells.

Dieser Fix behebt den Fehler.

---

> [!WARNING]
> Leider sind damit auch alle unsere bisherigen Ergebnisse obsolet. 

Ich würde heute und morgen versuchen die Läufe für _SVM_ (wobei ich hier keine Änderungen erwarte, weil ich diese Ergebnisse vor dem Change, der den Bug eingeführt hatte, berechnet hatte), _naive Bayes_ und _logistische Regression_ zu wiederholen. Die Ergebnisse würde ich dann mittels Pull Request ins Repository übertragen.
Dann stünde als nächster Schritt für den klassischen _ML_-Teil lediglich die Datenanalyse der Ergebnisse aus.