### PR TITLE
feat: add Deepseek R1 zero shot results for 1.5B, 8B and 32B models

### DIFF
--- a/datasets/sentiment140/results/deepseek-r1-1.5b-prompts-results-20250209-064806.json
+++ b/datasets/sentiment140/results/deepseek-r1-1.5b-prompts-results-20250209-064806.json
@@ -1,0 +1,2156 @@
+[
+    {
+        "reasoning": "The tweet expresses a strong emotional response towards her character and their Kindle2, highlighting deep affection and admiration for both the person and the device itself. The sentiment is positive because it conveys genuine happiness and appreciation.",
+        "sentiment": "positive",
+        "tweet": "@stellargirl I loooooooovvvvvveee my Kindle2. Not that the DX is cool, but the 2 is fantastic in its own right.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses a positive sentiment towards reading because it mentions that 'reading my Kindle' is loved, which conveys satisfaction with the content or experience. The mention of 'Lee childs is good read.' adds to this by highlighting enjoyment and appreciation for the material.",
+        "sentiment": "positive",
+        "tweet": "Reading my kindle2...  Love it... Lee childs is good read.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses strong approval and excitement about a product review for The Kindle 2 device.",
+        "sentiment": "positive",
+        "tweet": "Ok, first assesment of the #kindle2 ...it fucking rocks!!!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses enthusiasm about receiving a new Kindle 2, mentions the device's size and popularity, and uses positive language to encourage acceptance of the purchase.",
+        "sentiment": "positive",
+        "tweet": "@kenburbary You'll love your Kindle2. I've had mine for a few months and never looked back. The new big one is huge! No need for remorse! :)",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses agreement with a statement, which is generally considered neutral.",
+        "sentiment": "negative",
+        "tweet": "@mikefish  Fair enough. But i have the Kindle2 and I think it's perfect  :)",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses happiness after mentioning that a product (Kindle 2) is not too large, which may contribute to its appeal or ease of use.",
+        "sentiment": "positive",
+        "tweet": "@richardebaker no. it is too big. I'm quite happy with the Kindle2.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses strong dissatisfaction with economic policies that favor certain industries over others by not providing equal access to resources, which negatively impacts job creation and overall economic growth.",
+        "sentiment": "negative",
+        "tweet": "Fuck this economy. I hate aig and their non loan given asses.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a positive opinion about Jquery being its new best friend, which conveys a favorable sentiment towards it.",
+        "sentiment": "positive",
+        "tweet": "Jquery is my new best friend.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses love for Twitter, which is a platform that many people use to communicate and share information online.",
+        "sentiment": "positive",
+        "tweet": "Loves twitter",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "how can you not love Obama? he makes jokes about himself.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses strong disapproval of President Obama and Vice President Pesole's actions regarding political discussions aimed at destroying the core values of conservatism. The speaker believes that their leaders are not committed to fostering dialogue or unity among different political groups.",
+        "sentiment": "negative",
+        "tweet": "@Karoli I firmly believe that Obama/Pelosi have ZERO desire to be civil.  It's a charade and a slogan, but they want to destroy conservatism",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "House Correspondents dinner was last night whoopi, barbara &amp; sherri went, Obama got a standing ovation",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet contains multiple elements that contribute to its overall positivity, including humor from the video call interaction and the unexpected positive reaction from Lmao. The use of words like 'lebron' and 'puppet' adds a comedic effect which is uplifting for sentiment analysis.",
+        "sentiment": "positive",
+        "tweet": "Watchin Espn..Jus seen this new Nike Commerical with a Puppet Lebron..sh*t was hilarious...LMAO!!!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses strong disapproval of Nike's decision to use a controversial method (fly wire) for their products and criticizes it as wasteful and disrespectful.",
+        "sentiment": "negative",
+        "tweet": "dear nike, stop with the flywire. that shit is a waste of science. and ugly. love, @vincentx24x",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses admiration for LeBron as a basketball player but lacks clarity on whether it's an inter-sport debate or personal opinion. The language is neutral and open, which makes the sentiment uncertain.",
+        "sentiment": "negative",
+        "tweet": "#lebron best athlete of our generation, if not all time (basketball related) I don't want to get into inter-sport debates about   __1/2",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses support for a specific sports team, specifically mentioning his dislike of LeBron James. This indicates strong positive sentiment towards the team's brand.",
+        "sentiment": "positive",
+        "tweet": "I was talking to this guy last night and he was telling me that he is a die hard Spurs fan.  He also told me that he hates LeBron James.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a positive sentiment towards LeBron James because it mentions his name and provides a link to further information about him.",
+        "sentiment": "positive",
+        "tweet": "i love lebron. http://bit.ly/PdHur",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses support for LeBron James as he continues to showcase his basketball skills throughout the game until the final moments. The use of words like 'Beast' and 'A..til the end' conveys enthusiasm and anticipation, suggesting a positive sentiment towards him.",
+        "sentiment": "positive",
+        "tweet": "@ludajuice Lebron is a Beast, but I'm still cheering 4 the A..til the end.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The word 'boss' suggests a high level of authority and respect,",
+        "sentiment": "negative",
+        "tweet": "@Pmillzz lebron IS THE BOSS",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses support for LeBron as a fan of the Los Angeles Lakers team. It uses casual language and emojis like :), which convey happiness or approval. The sentiment is positive because it reflects admiration and excitement towards his fans.",
+        "sentiment": "positive",
+        "tweet": "@sketchbug Lebron is a hometown hero to me, lol I love the Lakers but let's go Cavs, lol",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet mentions two basketball players who are described as being amazing together. This suggests a positive tone, indicating that they have a good relationship and mutual admiration among fans or followers.",
+        "sentiment": "positive",
+        "tweet": "lebron and zydrunas are such an awesome duo",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses admiration for LeBron James as he's described as 'a beast' by his fans, but it also mentions that no one in the NBA can come close to him. This creates an imbalance where some people find him impressive while others feel like they're missing out on potential,",
+        "sentiment": "negative",
+        "tweet": "@wordwhizkid Lebron is a beast... nobody in the NBA comes even close.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses excitement about downloading apps on a iPhone, highlighting its popularity among users who enjoy various activities like gaming or browsing the web. The use of emojis adds to the positive connotation, suggesting satisfaction with the choice and ease of access.",
+        "sentiment": "positive",
+        "tweet": "downloading apps for my iphone! So much fun :-) There literally is an app for just about anything.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses hope after receiving good news and mentions scammers as threats. The language is positive but contains negative elements.",
+        "sentiment": "negative",
+        "tweet": "good news, just had a call from the Visa office, saying everything is fine.....what a relief! I am sick of scams out there! Stealing!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet contains a link to another Twitter account, which is common for social media posts but does not inherently convey positive or negative sentiment. The phrase 'come back' suggests a return or continuation of something, which could be neutral or even positive depending on context.",
+        "sentiment": "positive",
+        "tweet": "http://twurl.nl/epkr4b - awesome come back from @biz (via @fredwilson)",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses gratitude towards R &amp;R by mentioning it as a provider during a special occasion, which is considered important.",
+        "sentiment": "positive",
+        "tweet": "In montreal for a long weekend of R&amp;R. Much needed.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses support for Booz Allen's social media platform, highlighting its popularity among fans of his work. This positive statement contributes to the overall sentiment being positive.",
+        "sentiment": "positive",
+        "tweet": "Booz Allen Hamilton has a bad ass homegrown social collaboration platform. Way cool!  #ttiv",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet contains a hyperlink, which is not directly related to sentiment analysis of text content.",
+        "sentiment": "negative",
+        "tweet": "[#MLUC09] Customer Innovation Award Winner: Booz Allen Hamilton -- http://ping.fm/c2hPP",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses that the user has used two cameras: a Nikon D90 and aCanon 40D/50D, with their preference being the Nikon D90 due to its video features. The sentiment is positive because it highlights satisfaction in using one camera over another.",
+        "sentiment": "positive",
+        "tweet": "@SoChi2 I current use the Nikon D90 and love it, but not as much as the Canon 40D/50D. I chose the D90 for the  video feature. My mistake.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses support for Google being a good place to work and mentions working with a family member, which are positive elements.",
+        "sentiment": "positive",
+        "tweet": "@phyreman9 Google is always a good place to look. Should've mentioned I worked on the Mustang w/ my Dad, @KimbleT.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses frustration after using a Google device, which is known for its security features like strong encryption and malware detection. This makes the user feel uneasy about the situation and decides to use an alternative phone they trust more.",
+        "sentiment": "negative",
+        "tweet": "Played with an android google phone. The slide out screen scares me I would break that fucker so fast. Still prefer my iPhone.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet mentions that US plans to resume military tribunals, specifically referring to Guantanamo Bay. It highlights that these tribunals will consist of executives from the U.S. Intelligence Group (AIG) and debt holders from Chrysler. This information is critical because it could have significant implications for international relations, particularly regarding U.S.-China tensions and potential trade disputes or military cooperation with China.",
+        "sentiment": "negative",
+        "tweet": "US planning to resume the military tribunals at Guantanamo Bay... only this time those on trial will be AIG execs and Chrysler debt holders",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses frustration due to being bored, having untouchable tattoos, and feeling unhelpful with an equation. These elements create a negative emotional response.",
+        "sentiment": "negative",
+        "tweet": "omg so bored &amp; my tattoooos are so itchy!!  help! aha =)",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses frustration due to being itchy and unhappy.",
+        "sentiment": "negative",
+        "tweet": "I'm itchy and miserable!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses that 'I am not itchy' at a neutral time, suggesting they are comfortable but may become more so as time passes.",
+        "sentiment": "negative",
+        "tweet": "@sekseemess no. I'm not itchy for now. Maybe later, lol.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a strong emotional connection to a subject taught at Stanford, which is considerednerdy and fun. It also mentions missing out on that experience through online content.",
+        "sentiment": "negative",
+        "tweet": "RT @jessverr I love the nerdy Stanford human biology videos - makes me miss school. http://bit.ly/13t7NR",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses that the user has experienced some challenges with 'LyX' due to its steep learning curve. However, they mention that even after overcoming these difficulties, handling longer documents is very efficient and enjoyable. The sentiment appears to be positive because despite initial hurdles, the benefits of using LyX for shorter tasks are significant.",
+        "sentiment": "positive",
+        "tweet": "@spinuzzi: Has been a bit crazy, with steep learning curve, but LyX is really good for long docs. For anything shorter, it would be insane.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses positive emotions towards a person and their work. The use of phrases like 'I'm listening to' and 'so amazing' conveys satisfaction and admiration for the artist.",
+        "sentiment": "positive",
+        "tweet": "I'm listening to \"P.Y.T\" by Danny Gokey &lt;3 &lt;3 &lt;3 Aww, he's so amazing. I &lt;3 him so much :)",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses uncertainty about whether someone will go out for a sleep and then engage in a bike ride, which suggests that it's not clear if there are any negative intentions behind this action. The use of emojis like :D can indicate surprise or confusion but do not convey strong emotions.",
+        "sentiment": "negative",
+        "tweet": "is going to sleep then on a bike ride:]",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user mentioned that they can't sleep and their tooth is aching. This indicates dissatisfaction with both aspects, which suggests an overall negative sentiment towards the situation.",
+        "sentiment": "negative",
+        "tweet": "cant sleep... my tooth is aching.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a lack of interest in any new activities or plans due to repetition of phrases ('blah' etc.) and no mention of future events. The tone is indifferent with no positive or negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "Blah, blah, blah same old same old. No plans today, going back to sleep I guess.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "glad i didnt do Bay to Breakers today, it's 1000 freaking degrees in San Francisco wtf",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet contains a link, which is not an opinionated statement but rather a source of information or content. The mention of Obama's administration stopping bonuses and referring to AIG as a ponzi scheme suggests political intent but does not express any positive or negative sentiment towards the topic itself.",
+        "sentiment": "negative",
+        "tweet": "?Obama Administration Must Stop Bonuses to AIG Ponzi Schemers ... http://bit.ly/2CUIg",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses uncertainty about whether Citi will face challenges, such as a financial crisis or becoming an AI competitor. It suggests evaluating their resilience and competitive position to determine if they can adapt effectively in uncertain times.",
+        "sentiment": "negative",
+        "tweet": "started to think that Citi is in really deep s&amp;^t. Are they gonna survive the turmoil or are they gonna be the next AIG?",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet contains a strong negative word ('hate'n') which conveys dissatisfaction towards someone else's behavior, indicating a negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "ShaunWoo hate'n on AiG",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses excitement about attending a show that was well-received, indicating a positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "@YarnThing you will not regret going to see Star Trek. It was AWESOME!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses a controversial opinion about Michael Lewis and Malcolm Gladwell, suggesting it's not widely accepted or is considered odd by many.",
+        "sentiment": "negative",
+        "tweet": "annoying new trend on the internets:  people picking apart michael lewis and malcolm gladwell.  nobody wants to read that.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a recommendation for an online course, which is generally considered a positive sentiment as it can provide valuable information. The use of social media platforms like tinyurl.com suggests that the author may have had some prior experience or knowledge about the topic.",
+        "sentiment": "positive",
+        "tweet": "Highly recommend: http://tinyurl.com/HowDavidBeatsGoliath by Malcolm Gladwell",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses admiration for Malcolm Gladwell's work on books about human behavior and his concept of a tipping point, which are both highly regarded in their fields. It also mentions an exciting new book that builds upon these ideas. This positive sentiment is evident as the author emphasizes the importance of understanding human nature through literature and highlights the transformative potential of such knowledge.",
+        "sentiment": "positive",
+        "tweet": "Blink by malcolm gladwell amazing book and The tipping point!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The word 'man crush' suggests a romantic or affectionate relationship between two people. It does not convey any strong emotional or political connotations, so it is likely intended to express positive feelings about the person Malcolm Gladwell.",
+        "sentiment": "positive",
+        "tweet": "Malcolm Gladwell might be my new man crush",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user provided a tweet that expresses strong emotions towards watching sports content on ESPN. They mention feeling ",
+        "sentiment": "negative",
+        "tweet": "omg. The commercials alone on ESPN are going to drive me nuts.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses enjoyment of using the Twitter API, which is positive.",
+        "sentiment": "positive",
+        "tweet": "@robmalon Playing with Twitter API sounds fun.  May need to take a class or find a new friend who like to generate results with API code.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet contains a greeting message that expresses happiness towards users of Twitter API. It does not contain any explicit content or harmful language, so it is considered neutral.",
+        "sentiment": "positive",
+        "tweet": "Hello Twitter API ;)",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses frustration about Twitter API performance and client issues.",
+        "sentiment": "negative",
+        "tweet": "@morind45 Because the twitter api is slow and most client's aren't good.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The word 'butt' suggests something unpleasant or unappealing.",
+        "sentiment": "negative",
+        "tweet": "yahoo answers can be a butt sometimes",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a desire to scrapbook while expressing excitement about it being named after Nic. The use of ",
+        "sentiment": "positive",
+        "tweet": "is scrapbooking with Nic =D",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses a comparison between what Wolfram Alpha does better than Google, highlighting differences and strengths. This suggests that the sentiment is positive as it conveys constructive feedback about the relative performance of two search engines.",
+        "sentiment": "positive",
+        "tweet": "RT @mashable: Five Things Wolfram Alpha Does Better (And Vastly Different) Than Google - http://bit.ly/6nSnR",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses enthusiasm for playing basketball because it's related to\u7bee\u7403 (bball), which is associated with sports that are considered fun and positive.",
+        "sentiment": "positive",
+        "tweet": "just changed my default pic to a Nike basketball cause bball is awesome!!!!!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses frustration due to a company layoff, which is a negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "RT @SmartChickPDX: Was just told that Nike layoffs started today :-(",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a strong endorsement of a particular phrase ('JUST DO IT') used by someone (likely an employee) at Nike, highlighting their positive attitude and admiration towards that sentiment. The use of emojis adds to the emotional impact, suggesting genuine support for the word chosen.",
+        "sentiment": "positive",
+        "tweet": "Back when I worked for Nike we had one fav word : JUST DO IT! :)",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses admiration for a highly rated YouTube video on a specific topic related to fashion and technology. The mention of an inspiring commercial highlights personal motivation and enthusiasm in the subject area.",
+        "sentiment": "positive",
+        "tweet": "By the way, I'm totally inspired by this freaky Nike commercial: http://snurl.com/icgj9",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses excitement about attending a class event on Friday.",
+        "sentiment": "positive",
+        "tweet": "Class... The 50d is supposed to come today :)",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses a strong desire for an explanation but does not express any opinion about its content, so it is neutral.",
+        "sentiment": "negative",
+        "tweet": "needs someone to explain lambda calculus to him! :(",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses frustration about taking a graduate field exam, specifically mentioning that lambda calculus is too complex or difficult to understand and feels like being stuck with nothing but code errors. The speaker's feelings are clearly negative towards the subject matter and difficulty.",
+        "sentiment": "negative",
+        "tweet": "Took the Graduate Field Exam for Computer Science today.  Nothing makes you feel like more of an idiot than lambda calculus.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses gratitude and thanks to multiple people, which indicates a positive sentiment. The use of words like 'SHOUT OUTS TO' and 'THANKS TO' reinforces the idea that the speaker is appreciating others,",
+        "sentiment": "positive",
+        "tweet": "SHOUT OUTS TO ALL EAST PALO ALTO FOR BEING IN THE BUILDIN KARIZMAKAZE 50CAL GTA! ALSO THANKS TO PROFITS OF DOOM UNIVERSAL HEMPZ CRACKA......",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses a strong negative opinion about living in East Palo Alto during the summer because of its association with legal issues and potential safety concerns. The speaker is critical of the location, implying that they would not want to live there if such issues were present.",
+        "sentiment": "negative",
+        "tweet": "@legalgeekery Yeahhhhhhhhh, I wouldn't really have lived in East Palo Alto if I could have avoided it.  I guess it's only for the summer.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses gratitude towards Stanford University, which is a well-known institution with positive reputation. The mention of 'Great' reinforces that sentiment as it's often used in positive contexts like recommendations or praise. Additionally, the use of words like 'helpful', 'informative', and 'public' all contribute to a positive tone. There are no negative terms here.",
+        "sentiment": "positive",
+        "tweet": "@accannis @edog1203 Great Stanford course. Thanks for making it available to the public! Really helpful and informative for starting off!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses excitement about finishing work at six o'clock and plans to attend a game for the Los Angeles Lakers.",
+        "sentiment": "positive",
+        "tweet": "@ work til 6pm... lets go lakers!!!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses strong dissatisfaction towards North Korea's actions against China, which are seen as a violation of international law and human rights.",
+        "sentiment": "negative",
+        "tweet": "Damn you North Korea. http://bit.ly/KtMeQ",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a strong desire to eliminate North Korea's influence on global affairs, suggesting a positive intention towards peaceful resolution of tensions between nations.",
+        "sentiment": "positive",
+        "tweet": "Can we just go ahead and blow North Korea off the map already?",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses strong dissatisfaction towards North Korea's behavior of being too aggressive and disrespectful to Chinese people. The mention of the website indicates that it is a source for information about North Korea, which may be seen as offensive or inappropriate.",
+        "sentiment": "negative",
+        "tweet": "North Korea, please cease this douchebaggery. China doesn't even like you anymore. http://bit.ly/NeHSl",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses frustration about Pelosi's actions in a manner that seems unrelated to Chinese politics, suggesting he may be targeting specific issues outside of China. The language used appears confrontational and dismissive.",
+        "sentiment": "negative",
+        "tweet": "Why the hell is Pelosi in freakin China? and on whose dime?",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses concern about burning more cash than other companies like Chrysler and GM, suggesting a negative outlook on financial stability. It warns against a financial crisis caused by excessive bailouts.",
+        "sentiment": "negative",
+        "tweet": "Are YOU burning more cash $$$ than Chrysler and GM? Stop the financial tsunami. Where \"bailout\" means taking a handout!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses concern about an infection affecting a part of your spinach plant. The word 'infected' suggests that there is some form of illness present, which could be harmful or even fatal.",
+        "sentiment": "negative",
+        "tweet": "insects have infected my spinach plant :(",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a desire to help others, despite negative experiences and frustration. The use of words like 'n' (which can mean 'and') suggests that it's acknowledging past mistakes but also expressing hope for improvement or better outcomes. The sentiment is positive because it shows resilience and the intention to make amends.",
+        "sentiment": "positive",
+        "tweet": "wish i could catch every mosquito in the world n burn em slowly.they been bitin the shit outta me 2day.mosquitos are the assholes of insects",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses frustration about encountering insects after a religious event. The use of words like 'hate' and 'insects' suggests strong emotional disconnection or discomfort with nature.",
+        "sentiment": "negative",
+        "tweet": "just got back from church, and I totally hate insects.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses frustration with McDonald's food, mentions a health issue, and states that the team hasn't made progress towards their goals. These elements contribute to a negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "Just got mcdonalds goddam those eggs make me sick. O yeah Laker up date go lakers. Not much of an update? Well it's true so suck it",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a strong desire to eat at McDonald's, expressing excitement about it being open.",
+        "sentiment": "positive",
+        "tweet": "omgg i ohhdee want mcdonalds damn i wonder if its open lol =]",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses frustration due to an intense study session leading up to a history exam.",
+        "sentiment": "negative",
+        "tweet": "History exam studying ugh",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user expresses strong disapproval towards revision as a study method due to its boredom and lack of engagement. The mention of an upcoming exam highlights the potential negative impact on their performance. Additionally, the use of exclamation marks indicates extreme frustration and disappointment in expressing this sentiment.",
+        "sentiment": "negative",
+        "tweet": "I hate revision, it's so boring! I am totally unprepared for my exam tomorrow :( Things are not looking good...",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "Higher physics exam tommorow, not lookin forward to it much :(",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "It's a bank holiday, yet I'm only out of work now. Exam season sucks:(",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet mentions that Chenoweth and Bush are the real culprits, which suggests they have been involved in a significant issue. The link provided is to an article discussing this matter.",
+        "sentiment": "negative",
+        "tweet": "Cheney and Bush are the real culprits - http://fwix.com/article/939496",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses frustration with both the user's life and that of Dick Cheney, using hashtags to emphasize the negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "Life?s a bitch? and so is Dick Cheney. #p2 #bipart #tlot #tcot #hhrs #GOP #DNC http://is.gd/DjyQ",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet discusses Dick Cheney's controversial speech on topics like torture, terror, and Obama administration policies. It also includes a link to Fred Kaplan Slate.",
+        "sentiment": "negative",
+        "tweet": "Dick Cheney's dishonest speech about torture, terror, and Obama. -Fred Kaplan Slate. http://is.gd/DiHg",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses strong support for an opponent's political stance that is clearly negative towards abortion. The use of hyperbole and repetition suggests a critical view or criticism of the opponent's position.",
+        "sentiment": "negative",
+        "tweet": "\"The Republican party is a bunch of anti-abortion zealots who couldn't draw flies to a dump.\" -- Neal Boortz (just now, on the radio)",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet questions whether Twitter's connections API is working correctly by mentioning that some tweets did not reach their intended destinations.",
+        "sentiment": "negative",
+        "tweet": "is Twitter's connections API broken? Some tweets didn't make it to Twitter...",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses strong frustration and anger towards Twitter's API timeout feature, which is clearly a major issue that impacts user experience significantly.",
+        "sentiment": "negative",
+        "tweet": "i srsly hate the stupid twitter API timeout thing, soooo annoying!!!!! :(",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses enthusiasm for the book by mentioning that it was recommended, which indicates positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "@psychemedia I really liked @kswedberg's \"Learning jQuery\" book. http://bit.ly/pg0lT is worth a look too",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet mentions a product (Adobe CS4) and its developer (Goodby, Silverstein & Partners), which are both known for innovation. The mention of the ad being from them adds credibility to the content. Additionally, the link provided is likely related to educational or professional purposes, further supporting that it's an informative piece.",
+        "sentiment": "positive",
+        "tweet": "Very Interesting Ad from Adobe by Goodby, Silverstein &amp; Partners - YouTube - Adobe CS4: Le Sens Propre http://bit.ly/VprpT",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses a positive note about leaving Silverstein Agency, mentioning a new website link and expressing hope for good results.",
+        "sentiment": "positive",
+        "tweet": "Goodby Silverstein agency new site! http://www.goodbysilverstein.com/ Great!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses a goodbye wish for Silverstein's new website, mentions enjoying it with positive sentiment and provides an emoji.",
+        "sentiment": "negative",
+        "tweet": "RT @designplay Goodby, Silverstein's new site: http://www.goodbysilverstein.com/ I enjoy it. *nice find!*",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses support for artists, specifically mentioning Psyop and Silverstein, which are known for their talent. It also includes a link to an online platform (After Effects) suggesting that the author is open to collaborating or using such tools in creative projects.",
+        "sentiment": "positive",
+        "tweet": "The ever amazing Psyop and Goodby Silverstein &amp; Partners for HP! http://bit.ly/g2rU8 Have to go play with After Effects now!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet mentions a viral video chart, which is generally positive because it indicates high engagement and interest in the content.",
+        "sentiment": "positive",
+        "tweet": "top ten most watched on Viral-Video Chart.  Love the nike #mostvaluablepuppets campaign from Wieden &amp; Kennedy http://bit.ly/nR1n9",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses excitement and strong emotions due to its use of exclamation marks.",
+        "sentiment": "positive",
+        "tweet": "zomg!!! I have a G2!!!!!!!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses disappointment after receiving feedback about IO2009, which is considered unlucky. The user then mentions that the group is free to attend and invites them via a link provided on Twitter.",
+        "sentiment": "negative",
+        "tweet": "Ok so lots of buzz from IO2009 but how lucky are they - a Free G2!! http://is.gd/Hyzl",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user received a free Google G2 Android phone to attend Google I/O.",
+        "sentiment": "positive",
+        "tweet": "just got a free G2 android at google i/o!!!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses a desire to move from one platform (G1) to another (G2), which is related to Google's initiatives. This suggests a positive sentiment as it indicates an intention for change or improvement in the use of technology and platforms.",
+        "sentiment": "positive",
+        "tweet": "Guess I'll be retiring my G1 and start using my developer G2 woot #googleio",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses happiness towards a specific event related to Philip's work at Google. The word 'happy' conveys a positive emotion, indicating satisfaction with his position or achievements.",
+        "sentiment": "positive",
+        "tweet": "I am happy for Philip being at GoogleIO today",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses excitement about a potential game between the Los Angeles Lakers and an unknown team, which may not be familiar to many people.",
+        "sentiment": "negative",
+        "tweet": "Lakers played great!  Cannot wait for Thursday night Lakers vs. ???",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet is about creating a fake sitcom on NBC for a new movie, which seems like it's promoting the creation of content that may not be real or accurate. The mention of 'viral marketing' suggests that this could have spread widely online, possibly to attract more viewers and promote the film.",
+        "sentiment": "negative",
+        "tweet": "Judd Apatow creates fake sitcom on NBC.com to market his new movie... viral marketing at its best. http://is.gd/K0yK",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses frustration with viral marketing tactics and the perceived lack of professionalism within the company, which leads to negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "VIRAL MARKETING FAIL. This Acia Pills brand oughta get shut down for hacking into people's messenger's.  i get 5-6 msgs in a day! Arrrgh!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a casual mood towards watching a movie, using phrases like 'watching' and 'Lmao', which are common to convey humor or light-heartedness. It does not express any strong positive sentiment about the content of the movie.",
+        "sentiment": "negative",
+        "tweet": "watching Night at The Museum . Lmao",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses a strong positive emotion as it highlights that the user loves night activities at the museum.",
+        "sentiment": "positive",
+        "tweet": "i loved night at the museum!!!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses happiness after a movie night, which is generally considered positive.",
+        "sentiment": "positive",
+        "tweet": "just got back from the movies.  went to see the new night at the museum with rachel.  it was good",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses excitement about taking someone for a date, mentioning seeing the night at the museum. It uses positive language and encourages waiting until desired time. The sentiment is positive.",
+        "sentiment": "positive",
+        "tweet": "@shannyoday I will take you on a date to see night at the museum 2 whenever you want...it looks soooooo good",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses a lack of interest in attending The Night at the Museum due to its length, which may not align with someone's time constraints.",
+        "sentiment": "negative",
+        "tweet": "no watching The Night At The Museum. Getting Really Good",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses enjoyment and positivity about a day out at the museum with Wolverine and mentions delicious junk food, which are both positive elements.",
+        "sentiment": "positive",
+        "tweet": "Night at the Museum, Wolverine and junk food - perfect monday!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses excitement about a recent experience, mentioning a movie watched with friends, highlighting positive emotions and praise for the film's cast. The sentiment is definitely positive.",
+        "sentiment": "positive",
+        "tweet": "saw night at the museum 2 last night.. pretty crazy movie.. but the cast was awesome so it was well worth it. Robin Williams forever!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses frustration about a change in plans, mentions an older child enjoying something fun, uses emojis to convey emotion.",
+        "sentiment": "negative",
+        "tweet": "Night at the Museum tonite instead of UP. :( oh well. that 4 yr old better enjoy it. LOL",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a sense of disappointment due to multiple attempts at stimulus measures, which may have hindered economic growth despite efforts. The use of 'inevitable' adds a negative connotation about potential future issues.",
+        "sentiment": "negative",
+        "tweet": "It's unfortunate that after the Stimulus plan was put in place twice to help GM on the back of the American people has led to the inevitable",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a strong opinion against supporting GM, stating that additional funds should be allocated towards other programs aimed at addressing unemployment. This indicates a clear and direct criticism of corporate actions.",
+        "sentiment": "negative",
+        "tweet": "Tell me again why we are giving more $$ to GM?? We should use that $ for all the programs that support the unemployed.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a mix of positivity and humor. It uses phrases like 'boo' and 'hahaha', which are playful, and includes an emoji @JDREISS. The overall tone is light-hearted with some sarcastic elements but still conveys happiness or joy.",
+        "sentiment": "positive",
+        "tweet": "@jdreiss oh yes but if GM dies it will only be worth more boo hahaha",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet mentions that Time Warner Cable has been down three times since Memorial Day, which indicates a lack of service availability. This suggests that there are issues with their network or reliability, leading to negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "Time Warner cable is down again 3rd time since Memorial Day bummer!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user prefers to spend money on free services like fast internet over potential financial losses from slower connections. This shows an understanding of value and prioritizing what they can afford.",
+        "sentiment": "negative",
+        "tweet": "I would rather pay reasonable yearly taxes for \"free\" fast internet, than get gouged by Time Warner for a slow connection.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user mentioned that their TV's DVR had a problem, which is a serious issue affecting productivity. They also expressed frustration towards Time Warner management for not addressing this critical issue.",
+        "sentiment": "negative",
+        "tweet": "NOOOOOOO my DVR just died and I was only half way through the EA presser. Hate you Time Warner",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet contains multiple negative words like 'f*ck,' 'suck,' and 'bullshit.' These words indicate strong disagreement with the statement, suggesting that the speaker strongly disagrees or finds it offensive.",
+        "sentiment": "negative",
+        "tweet": "F*ck Time Warner Cable!!! You f*cking suck balls!!! I have a $700 HD tv &amp; my damn HD channels hardly ever come in. Bullshit!!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses strong dissatisfaction with Time Warner's customer service, stating that it is worse than any other provider mentioned. It also explicitly states that this company will not be used by anyone else.",
+        "sentiment": "negative",
+        "tweet": "time warner has the worse customer service ever. I will never use them again",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses extreme frustration about Time Warner's actions regarding internet services, suggesting a worst-case scenario that could negatively impact the overall stability of the internet community.",
+        "sentiment": "negative",
+        "tweet": "Time warner is the devil. Worst possible time for the Internet to go out.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet contains a strong negative word ('fuck') which conveys extreme frustration and anger towards access to information through the internet.",
+        "sentiment": "negative",
+        "tweet": "Fuck no internet damn time warner!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses frustration because it mentions that Time Warner picked a bad time for working, which makes people feel like they're missing out on opportunities or being unproductive.",
+        "sentiment": "negative",
+        "tweet": "time warner really picks the worst time to not work. all i want to do is get to mtv.com so i can watch the hills. wtfffff.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses strong dissatisfaction towards Time Warner, mentions a desire for better software (Vios), and criticizes the Mets' performance without buffering options. These elements collectively convey negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "I hate Time Warner! Soooo wish I had Vios. Cant watch the fricken Mets game w/o buffering. I feel like im watching free internet porn.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses happiness after successfully removing an item from storage, followed by a peaceful evening with friends and family.",
+        "sentiment": "positive",
+        "tweet": "Ahh...got rid of stupid time warner today &amp; now taking a nap while the roomies cook for me. Pretty good end for a monday :)",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses dissatisfaction about Time Warner's HD movie streaming service being poorly rated.",
+        "sentiment": "negative",
+        "tweet": "Time Warner's HD line up is crap.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses strong dissatisfaction with both time warner cable and susan boyle, suggesting a deep-seated criticism of their respective organizations or individuals.",
+        "sentiment": "negative",
+        "tweet": "is being fucked by time warner cable. didnt know modems could explode. and Susan Boyle sucks too!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a strong negative sentiment as it uses words like 'calling' which implies urgency, and suggests that something will happen soon after midnight. This creates confusion for the audience about when their time is up.",
+        "sentiment": "negative",
+        "tweet": "Time Warner Cable slogan: Where calling it a day at 2pm Happens.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a positive sentiment towards Jules Renner's presence, as it shows someone is hoping for his support after undergoing surgery. The use of exclamation marks and the phrase 'wishing' indicate a desire to be supported or seen by others.",
+        "sentiment": "positive",
+        "tweet": "Recovering from surgery..wishing @julesrenner was here :(",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses frustration with pain on the wrist and mentions a doctor's office which is considered scary or concerning.",
+        "sentiment": "negative",
+        "tweet": "My wrist still hurts. I have to get it looked at. I HATE the dr/dentist/scary places. :( Time to watch Eagle eye. If you want to join, txt!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses strong negative sentiment towards the dentist's statement. The user is clearly upset and frustrated with the dentist's claims of no discomfort or pain, which they perceive as a lackluster service. They express frustration about how many pills they can take despite this.",
+        "sentiment": "negative",
+        "tweet": "THE DENTIST LIED! \" U WON'T FEEL ANY DISCOMORT! PROB WON'T EVEN NEED PAIN PILLS\" MAN U TWIPPIN THIS SHIT HURT!! HOW MANY PILLS CAN I TAKE!!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a mixed opinion about her dental care. It mentions that her dentist is good, which suggests satisfaction, but also highlights that it's expensive, indicating dissatisfaction with the cost.",
+        "sentiment": "negative",
+        "tweet": "@kirstiealley my dentist is great but she's expensive...=(",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a mix of enthusiasm for studying mathematics and excitement about an upcoming dental appointment. Both elements are positive, suggesting overall happiness.",
+        "sentiment": "positive",
+        "tweet": "is studing math ;) tomorrow exam and dentist :)",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet contains a clear statement that contradicts itself by claiming to visit my dentist but then stating it's incorrect.",
+        "sentiment": "negative",
+        "tweet": "my dentist was wrong... WRONG",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a desire for going out after dental procedures but does not contain any explicit language that conveys strong emotions towards positive or negative aspects.",
+        "sentiment": "negative",
+        "tweet": "Going to the dentist later.:|",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses strong dissatisfaction with car shopping, as it highlights the negative feelings towards purchasing and using vehicles for personal use. The speaker mentions hating car shopping and prefers going to the dentist instead of visiting a dealership or selling their own cars. This indicates a clear negative sentiment toward acquiring and valuing personal assets through buying cars.",
+        "sentiment": "negative",
+        "tweet": "Son has me looking at cars online.  I hate car shopping.  Would rather go to the dentist!  Anyone with a good car at a good price to sell?",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a level of enthusiasm for an activity, which suggests positive emotions.",
+        "sentiment": "positive",
+        "tweet": "luke and i got stopped walking out of safeway and asked to empty our pockets and lift our shirts. how jacked up is that?",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet mentions 'rock n roll' which is a genre that's generally associated with positive emotions, like excitement and energy. Rock music can be uplifting and fun for people who enjoy it.",
+        "sentiment": "positive",
+        "tweet": "Safeway is very rock n roll tonight",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses strong disapproval of a specific behavior (smelling like an adult's body), which aligns with negative emotions.",
+        "sentiment": "negative",
+        "tweet": "The safeway bathroom still smells like ass!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a sense of despair and fear due to its imagery of something moving at an alarming rate towards death.",
+        "sentiment": "negative",
+        "tweet": "At safeway on elkhorn, they move like they're dead!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a preference for Dwight Howard's commercial but also mentions wishing someone else, which can be seen as negative.",
+        "sentiment": "negative",
+        "tweet": "i love Dwight Howard's vitamin water commercial... now i wish he was with NIKE and not adidas. lol.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses disappointment that there's nothing found at the Nike Factory, which is a negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "Found NOTHING at Nike Factory :/ Off to Banana Republic Outlet! http://myloc.me/2zic",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "is lovin his Nike  already and that's only from running on the spot in his bedroom",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses a positive emotion after successfully implementing jQuery, which is related to web development and can be seen as constructive or helpful.",
+        "sentiment": "positive",
+        "tweet": "@matthewcyan I finally got around to using jquery to make my bio collapse. Yay for slide animations.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses excitement and anticipation for an upcoming event, as it uses words like 'right!!!' and 'LOL' which are playful and positive. It also mentions high expectations similar to those of a Warren Buffett fan, suggesting the speaker is looking forward to something significant.",
+        "sentiment": "positive",
+        "tweet": "@PDubyaD right!!! LOL we'll get there!! I have high expectations, Warren Buffet style.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses admiration for Warren Buffett, as he is known to value nature and plantings. The phrase suggests that someone has spent considerable time planting trees, which adds to the natural setting of his comment. This positive sentiment towards enhancement or appreciation of a person's work contributes positively to the overall mood.",
+        "sentiment": "positive",
+        "tweet": "RT @blknprecious1: RT GREAT @dbroos \"Someone's sitting in the shade today because someone planted a tree a long time ago.\"- Warren Buffet",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet discusses Warren Buffett's investment strategies leading to wealth growth. It uses positive language like 'incredible' and 'insightful.' The sentiment is positive because it highlights his success through strategic investments.",
+        "sentiment": "positive",
+        "tweet": "Warren Buffet became (for a time) the richest man in the United States, not by working but investing in 1 Big idea which lead to the fortune",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses support for Notre Dame's decision to send seven receivers into college with ratings of 84 or above. The use of 'sweeter' adds a positive connotation, indicating satisfaction and success in the recruitment process.",
+        "sentiment": "positive",
+        "tweet": "According to the create a school, Notre Dame will have 7 receivers in NCAA 10 at 84 or higher rating :) *sweet*",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses that the product has been under warranty, which suggests a positive sentiment. The user mentions Amazon's excellent support and their own experiences withKindle 2, indicating satisfaction and trustworthiness in both products. There are no negative or neutral language used.",
+        "sentiment": "positive",
+        "tweet": "@BlondeBroad it's definitely under warranty &amp; my experience is the amazon support for kindle is great! had to contact them about my kindle2",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses strong dissatisfaction with Time Warner's customer service, which is described as excellent but lacking alternatives for high-speed internet access. The user also mentions a desire for more flexibility and advanced features in their network setup.",
+        "sentiment": "negative",
+        "tweet": "Time Warner Road Runner customer support here absolutely blows. I hate not having other high-speed net options. I'm ready to go nuclear.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet contains a clear contradiction between two statements about Time Warner's representatives, which suggests negative sentiment. The first statement compares the reps to someone who is ",
+        "sentiment": "negative",
+        "tweet": "Time Warner cable phone reps r dumber than nails!!!!! UGH! Cable was working 10 mins ago now its not WTF!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses frustration because it mentions that Time Warner isn't being nice, which is a strong indicator of dissatisfaction.",
+        "sentiment": "negative",
+        "tweet": "@siratomofbones we tried but Time Warner wasn't being nice so we recorded today. :)",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses frustration and disappointment with the user's inability to connect with their online activities. The mention of a time warp, an update on when they'll have access again, and the use of exclamation points highlight dissatisfaction. Additionally, the inclusion of hashtags like #fml suggests that the content is related to gaming or social media in general.",
+        "sentiment": "negative",
+        "tweet": "OMG - time warner f'ed up my internet install - instead of today  its now NEXT saturday - another week w/o internet! &amp;$*ehfa^V9fhg[*# fml.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses frustration due to its length exceeding expectations. The user has not encountered such long tweets previously.",
+        "sentiment": "negative",
+        "tweet": "wth..i have never seen a line this loooong at time warner before, ugh.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a lack of interest in waiting for someone, which shows impatience. The phrase 'way too pretty' suggests beauty or allure, but it doesn't convey enthusiasm towards any specific event during the day.",
+        "sentiment": "negative",
+        "tweet": "Impatiently awaiting the arrival of the time warner guy. It's way too pretty to be inside all afternoon",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses frustration due to the use of Naive Bayes with Expectation-Maximization (EM) algorithm in text classification, which is known for its computational efficiency despite being less accurate compared to other methods like Support Vector Machines or Decision Trees.",
+        "sentiment": "negative",
+        "tweet": "Naive Bayes using EM for Text Classification. Really Frustrating...",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses excitement about going back to Stanford after completing studies, mentions making the decision for children and expressing desire to return,",
+        "sentiment": "positive",
+        "tweet": "We went to Stanford University today. Got a tour. Made me want to go back to college. It's also decided all of our kids will go there.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses frustration regarding harassment related to a car warranty issue and advises against changing the phone number as it's targeted at all numbers. The use of 'they' suggests they are referring broadly or collectively, which implies broad-based issues rather than specific ones.",
+        "sentiment": "negative",
+        "tweet": "@KarrisFoxy If you're being harassed by calls about your car warranty, changing your number won't fix that. They call every number. #d-bags",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses frustration due to being blocked by a service that calls multiple people, which is seen as annoying compared to another service.",
+        "sentiment": "negative",
+        "tweet": "Just blocked United Blood Services using Google Voice. They call more than those Car Warranty guys.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "#at&amp;amp;t is complete fail.",
+        "sentiment": "negative",
+        "tweet": "#at&amp;t is complete fail.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses support for working at AT&T and mentions a specific company, which can be seen as reinforcing a positive work environment.",
+        "sentiment": "positive",
+        "tweet": "@broskiii OH SNAP YOU WORK AT AT&amp;T DON'T YOU",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses strong dissatisfaction with AT&T's phone service, specifically their inability to provide a reliable signal. The use of symbols like @ and & indicates the speaker is expressing frustration about the quality of service provided by the company.",
+        "sentiment": "negative",
+        "tweet": "@Mbjthegreat i really dont want AT&amp;T phone service..they suck when it comes to having a signal",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses strong disapproval of a proposed change that would reduce interaction with others by cutting out small talk and replacing it with financial requests.",
+        "sentiment": "negative",
+        "tweet": "I say we just cut out the small talk: AT&amp;T's new slogan: F__k you, give us your money. (Apologies to Bob Geldof.)",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses frustration and disappointment due to the perceived increase in cost. The speaker is clearly dissatisfied with the expected price, which they believe will be covered by their budget.",
+        "sentiment": "negative",
+        "tweet": "pissed about at&amp;t's mid-contract upgrade price for the iPhone (it's $200 more) I'm not going to pay $499 for something I thought was $299",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses happiness and enjoyment through a smiley emoji (:) and mentions that Safari 4 is fast, which suggests it's an enjoyable product. The mention of the user's AT&T tethering being 'shitty' might imply poor connectivity or issues with their device.",
+        "sentiment": "positive",
+        "tweet": "Safari 4 is fast :) Even on my shitty AT&amp;T tethering.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses frustration and anger towards @AT&TT's behavior.",
+        "sentiment": "negative",
+        "tweet": "@ims What is AT&amp;T fucking up?",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses frustration, disappointment, and negativity towards the company's failure to support their product or service. The use of words like 'drop', 'fail', and 'support' indicates a negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "@springsingfiend @dvyers @sethdaggett @jlshack AT&amp;T dropped the ball and isn't supporting crap with the new iPhone 3.0... FAIL #att SUCKS!!!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a lack of appreciation for @AT&T's support but still mentions their services.",
+        "sentiment": "negative",
+        "tweet": "@MMBarnhill yay, glad you got the phone! Still, damn you, AT&amp;T.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a preference for using Google over Bing due to its cheaper pricing model. The use of phrases like 'I?' and the request to stay loyal suggests a positive sentiment towards Google's value proposition.",
+        "sentiment": "positive",
+        "tweet": "Talk is Cheap: Bing that, I?ll stick with Google. http://bit.ly/XC3C8",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a desire to delete tweets from Sumrise after they are no longer accessible due to changes on Twitter. It also includes an offer for support with 'Thanks' followed by 'bye'. The sentiment is positive because the user seems willing to engage in communication despite the change.",
+        "sentiment": "positive",
+        "tweet": "@defsounds WTF is the point of deleting tweets if they can still be found in summize and searches? Twitter, please fix that. Thanks and bye",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses enthusiasm for using Google Translator and includes a friendly greeting, which suggests a positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "@ArunBasilLal I love Google Translator too ! :D Good day mate !",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses a desire to read on an electronic device, which can be beneficial for reading time. It's not explicitly stated whether it's positive or negative, but since it's about using technology for reading, and generally such activities are seen as positive in terms of productivity and convenience.",
+        "sentiment": "positive",
+        "tweet": "reading on my new Kindle2!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses a strong positive emotion as it highlights that the user loves their Kindle 2, which is a product they own.",
+        "sentiment": "positive",
+        "tweet": "My Kindle2 came and I LOVE it! :)",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses positive emotions towards the Kindle2, mentions a specific person named Kendra, and highlights that the cookbook serves as a comprehensive guide for various tasks. These elements contribute to a positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "LOVING my new Kindle2.  Named her Kendra in case u were wondering. The \"cookbook\" is THE tool cuz it tells u all the tricks!  Best gift EVR!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "I'm not sure about this one.",
+        "sentiment": "negative",
+        "tweet": "The real AIG scandal / http://bit.ly/b82Px",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses support for Obama's ability to be a good comedian, mentions checking out his dinner speech on CNN, and highlights that it was very funny with numerous jokes. The sentiment appears positive because all these elements contribute to a favorable overall impression of the speaker.",
+        "sentiment": "positive",
+        "tweet": "Obama is quite a good comedian! check out his dinner speech on CNN :) very funny jokes.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses a humorous take on an important political figure, which is generally considered neutral to positive.",
+        "sentiment": "positive",
+        "tweet": "' Barack Obama shows his funny side \" &gt;&gt; http://tr.im/l0gY !! Great speech..",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses admiration for a person, highlighting their personality and humor.",
+        "sentiment": "positive",
+        "tweet": "I like this guy : ' Barack Obama shows his funny side \" &gt;&gt; http://tr.im/l0gY !!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses praise for Obama's speech and provides a link to his address on Twitter, which is common practice when sharing such information. The use of an image URL suggests that the speaker might have included visual evidence or context in their message.",
+        "sentiment": "positive",
+        "tweet": "Obama's speech was pretty awesome last night! http://bit.ly/IMXUM",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet contains a link to an image that shows Bill Clinton failing on a key point of his campaign against Obama, which is often cited as evidence of the failure of the administration. The mention of 'Fail' and 'Win' suggests a negative sentiment towards the administration's performance.",
+        "sentiment": "negative",
+        "tweet": "Reading  \"Bill Clinton Fail - Obama Win?\" http://tinyurl.com/pcyxj7",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet mentions that Obama is more popular than the U.S. among Arabs, referencing a survey conducted by the Organization of Islamic Cooperation (OIC). It also provides a link to further information.",
+        "sentiment": "negative",
+        "tweet": "Obama More Popular Than U.S. Among Arabs: Survey: President Barack Obama's popularity in leading Arab countries .. http://tinyurl.com/prlvqu",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses enthusiasm for Obama, mentions jokes, suggests watching his speech afterward, and highlights the President's affection. These elements are positive indicators of a favorable sentiment towards him.",
+        "sentiment": "positive",
+        "tweet": "Obama's got JOKES!! haha just got to watch a bit of his after dinner speech from last night... i'm in love with mr. president ;)",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses concern about LeBron James's health after an unexpected event. It uses the word 'wows' and poses a question, which suggests doubt or disbelief in his well-being. The mention of a car accident on the evening news adds credibility to the situation but doesn't change its emotional weight.",
+        "sentiment": "negative",
+        "tweet": "LEbron james got in a car accident i guess..just heard it on evening news...wow i cant believe it..will he be ok ? http://twtad.com/69750",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a strong opinion about whether it's referring to LeBron or Melo during the playoffs, which suggests a negative sentiment towards these two athletes. The use of 'is' twice indicates agreement with their presence, implying dissatisfaction.",
+        "sentiment": "negative",
+        "tweet": "is it me or is this the best the playoffs have been in years oh yea lebron and melo in the finals",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses a clear opinion that Lebron James is not as good as someone else mentioned, which suggests a negative sentiment towards his performance.",
+        "sentiment": "negative",
+        "tweet": "@khalid0456 No, Lebron is the best",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses admiration for @the_real_usher and mentions LeBron's coolness and personality, which are both positive traits.",
+        "sentiment": "positive",
+        "tweet": "@the_real_usher LeBron is cool.  I like his personality...he has good character.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses support for basketball players who are considered less skilled than others but still perform well, which can be seen as a mix of admiration and criticism.",
+        "sentiment": "negative",
+        "tweet": "Watching Lebron highlights. Damn that niggas good",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet uses expletives to express strong disagreement about LeBron's actions.",
+        "sentiment": "negative",
+        "tweet": "@Lou911 Lebron is MURDERING shit.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses frustration, criticism, and negativity towards LeBron's claim of being an Monster, which is unrealistic given his age. It also uses sarcastic language ('SMH') to further convey negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "@uscsports21 LeBron is a monsta and he is only 24. SMH The world ain't ready.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses a belief that after LeBron's injury, Kobe might become even better or more exceptional compared to others who are already known as good players. It suggests that Lebron's absence could lead to greater distinction among the NBA community by elevating Kobe's status beyond what is currently recognized.",
+        "sentiment": "negative",
+        "tweet": "@cthagod when Lebron is done in the NBA he will probably be greater than Kobe. Like u said Kobe is good but there alot of 'good' players.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses support for Kobe Bryant and LeBron James, which are both well-known athletes who have made significant contributions to their respective sports. The use of 'my vote' suggests that the speaker is expressing approval or endorsement towards these individuals.",
+        "sentiment": "positive",
+        "tweet": "KOBE IS GOOD BT LEBRON HAS MY VOTE",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet states that Kobe is considered better than LeBron but does not provide any information about their actual performance levels, making it impossible to determine a clear positive or negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "Kobe is the best in the world not lebron .",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses admiration for @asherroth's mention of 'Access' during the World Cup 2010, suggesting he is knowledgeable about sports and competitions. The use of 'good look' conveys positive sentiment towards his comment.",
+        "sentiment": "positive",
+        "tweet": "@asherroth World Cup 2010 Access?? Damn, that's a good look!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "Just bought my tickets for the 2010 FIFA World Cup in South Africa. Its going to be a great summer. http://bit.ly/9GEZI",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expresses frustration during their meeting, which is followed by relief upon returning home.",
+        "sentiment": "negative",
+        "tweet": "I have to go to Booz Allen Hamilton for a 2hr meeting :(  But then i get to go home :)",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a hopeful expectation about an upcoming election event, which is generally considered to be positive.",
+        "sentiment": "positive",
+        "tweet": "The great Indian tamasha truly will unfold from May 16, the result day for Indian General Election.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses that the user has received a physical copy of their Kindle 2 and is currently using it daily. It also mentions they have seen pictures of another device (DX) but hasn't had access to it yet. The sentiment appears positive as the user is actively engaged with their device, which suggests satisfaction or contentment.",
+        "sentiment": "positive",
+        "tweet": "@crlane I have the Kindle2. I've seen pictures of the DX, but haven't seen it in person. I love my Kindle - I'm on it everyday.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses support for an idea, mentions a product (Kindle2) but does not provide any information about its quality or features. The language is positive and enthusiastic.",
+        "sentiment": "positive",
+        "tweet": "@criticalpath Such an awesome idea - the  continual learning program with a Kindle2  http://bit.ly/1ZLfF",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses excitement about receiving a new iPhone model, which is a positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "@faithbabywear Ooooh, what model are you getting??? I have the 40D and LOVE LOVE LOVE LOVE it!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "I noticed that this tweet links to a website, specifically bit.ly/p7u1H. This suggests it might be related to news or information about the election in India.",
+        "sentiment": "negative",
+        "tweet": "The Times of India: The wonder that is India's election. http://bit.ly/p7u1H",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses a recommendation for a good video from Google using its search features, which is generally considered positive.",
+        "sentiment": "positive",
+        "tweet": "http://is.gd/ArUJ Good video from Google on using search options.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses frustration due to skin irritation from a lawnmower, which makes me feel unwell.",
+        "sentiment": "negative",
+        "tweet": "@ambcharlesfield lol. Ah my skin is itchy :( damn lawnmowing.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet contains a playful remark about being stuck in an ",
+        "sentiment": "negative",
+        "tweet": "itchy back!! dont ya hate it!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet contains an image link that does not express any opinion or emotion, so it cannot be classified as positive or negative.",
+        "sentiment": "negative",
+        "tweet": "Stanford Charity Fashion Show a top draw http://cli.gs/NeNuAH",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet mentions that Stanford University's Facebook page is one of the most popular official university pages. This indicates a positive sentiment towards Stanford's social media presence and its alignment with the university's brand.",
+        "sentiment": "positive",
+        "tweet": "Stanford University?s Facebook Profile is One of the Most Popular Official University Pages - http://tinyurl.com/p5b3fl",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses a level of interest in Lyx but does not convey any strong opinion about its overall quality or effectiveness.",
+        "sentiment": "negative",
+        "tweet": "Lyx is cool.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses enthusiasm, excitement, and admiration for the speaker's success. The words used include 'DISSAPOI' which is a play on 'disappear,' suggesting something positive about their situation or achievements. The use of exclamation points reinforces a confident and enthusiastic tone. Additionally, phrases like 'STiLL ROCK ... DANNY ... MY HOMETOWN HERO ! YEAH MiLROCKEE!!' emphasize the speaker's success and personal connection to their hometown hero. These elements collectively convey a positive sentiment towards the tweet.",
+        "sentiment": "positive",
+        "tweet": "SOOO DISSAPOiNTED THEY SENT DANNY GOKEY HOME... YOU STiLL ROCK ...DANNY ... MY HOMETOWN HERO !! YEAH MiLROCKEE!!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet is a link to an image that shows two people from American Idol. The text mentions the actors and their styles but does not express any opinion or sentiment about them.",
+        "sentiment": "negative",
+        "tweet": "RT @PassionModel 'American Idol' fashion: Adam Lambert tones down, Danny Gokey cute ... http://cli.gs/7JWSHV",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses genuine happiness and affection towards @dannygokey. The use of emojis like :D adds to the positive tone, indicating a sense of community or admiration for the person.",
+        "sentiment": "positive",
+        "tweet": "@dannygokey I love you DANNY GOKEY!! :)",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses extreme difficulty in sleeping after a long day, which indicates a strong sense of tiredness.",
+        "sentiment": "negative",
+        "tweet": "so tired. i didn't sleep well at all last night.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses frustration due to a long wait at boarding, which is described as being bleached (suddenly becoming worse). The user is clearly upset and annoyed.",
+        "sentiment": "negative",
+        "tweet": "Boarding plane for San Francisco in 1 hour; 6 hr flight. Blech.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a lack of pain but does not mention any positive feelings.",
+        "sentiment": "negative",
+        "tweet": "bonjour San Francisco. My back hurts from last night..",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses happiness towards her and family members, which indicates a positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "With my best girl for a few more hours in San francisco. Mmmmmfamily is wonderful!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses strong dissatisfaction with a large group and suggests going home after an argument.",
+        "sentiment": "negative",
+        "tweet": "F*** up big, or go home - AIG",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user mentioned attending a movie event and expressed satisfaction upon finishing it.",
+        "sentiment": "positive",
+        "tweet": "Went to see the Star Trek movie last night.  Very satisfying.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses excitement about attending a future event related to Star Trek.",
+        "sentiment": "positive",
+        "tweet": "I can't wait, going to see star trek tonight!!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses approval and admiration towards Star Trek movies, reflecting a positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "Star Trek was as good as everyone said!!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet mentions a book by Malcolm Gladwell but refers to an outlier as 'outliers'.",
+        "sentiment": "negative",
+        "tweet": "am loving new malcolm gladwell book - outliers",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses a recommendation for Malcolm Gladwell's book, which is generally considered positive. The use of words like 'highly recommend' and 'probably' suggests that the author is likely to write about similar topics in their next work. This indicates a positive sentiment towards the book itself.",
+        "sentiment": "positive",
+        "tweet": "I highly recommend Malcolm Gladwell's 'The Tipping Point.' My next audiobook will probably be one of his as well.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses frustration about Malcolm Gladwell's claim that his expertise leads others to overlook his flaws, which he calls 'fucking idiots.' This suggests criticism of Gladwell's ability to recognize and address such issues.",
+        "sentiment": "negative",
+        "tweet": "Malcolm Gladwell is a genius at tricking people into not realizing he's a fucking idiot",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "Malcolm Gladwell's tweet about being pretentious and an insensitive person makes me feel bad because it undermines my ability to engage with the content.",
+        "sentiment": "negative",
+        "tweet": "@sportsguy33 hey no offense but malcolm gladwell is a pretenious, annoying cunt and he brings you down. cant read his shit",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses support for a controversial topic, which may be seen as opinionated but not necessarily negative.",
+        "sentiment": "positive",
+        "tweet": "RT @clashmore: http://bit.ly/SOYv7  Great article by Malcolm Gladwell.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses a strong desire to meet Malcolm Gladwell and highlights his influence on popular culture, which is generally considered positive.",
+        "sentiment": "positive",
+        "tweet": "I seriously underestimated Malcolm Gladwell.  I want to meet this dude.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "i hate comcast right now. everything is down cable internet &amp; phone....ughh what am i to do",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The word 'sucks' conveys a negative emotion because it implies that something bad has happened to someone else.",
+        "sentiment": "negative",
+        "tweet": "Comcast sucks.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "I don't know anything about this tweet, but it seems like a statement that's not based on any information or context. It just says something about dealing with Comcast and comparing it to other good things in life. Since I can't provide accurate sentiment analysis without more context, the sentiment is unknown.",
+        "sentiment": "negative",
+        "tweet": "The day I never have to deal with Comcast again will rank as one of the best days of my life.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses frustration about a failed broadcast event.",
+        "sentiment": "negative",
+        "tweet": "@Dommm did comcast fail again??",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user has mentioned that they are cursed by Twitter's API limits.",
+        "sentiment": "negative",
+        "tweet": "curses the Twitter API limit",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a strong opinion that highlights negative feelings towards certain aspects of Twitter's API. It uses emotional language to criticize these features.",
+        "sentiment": "negative",
+        "tweet": "Now I can see why Dave Winer screams about lack of Twitter API, its limitations and access throttles!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user mentioned that their Twitter API is causing them some confusion.",
+        "sentiment": "negative",
+        "tweet": "Arg. Twitter API is making me crazy.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a strong endorsement of Wolfram Alpha, highlighting its innovative nature and user-friendly design despite some negative remarks about Google.",
+        "sentiment": "negative",
+        "tweet": "I'm really loving the new search site Wolfram/Alpha. Makes Google seem so ... quaint. http://www72.wolframalpha.com/",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses frustration about Wolfram Alpha's performance compared to Google and Wikipedia. It highlights that Wolfram Alpha provides insufficient information even for researchers, which makes it seem like a worse tool in comparison.",
+        "sentiment": "negative",
+        "tweet": "#wolfram Alpha SUCKS! Even for researchers the information provided is less than you can get from #google or #wikipedia, totally useless!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses excitement about visiting a nearby Nike factory but does not contain any explicit content.",
+        "sentiment": "negative",
+        "tweet": "Off to the NIKE factory!!!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses a mix of feelings about New York City's commercial sports teams, but it doesn't contain any explicit content that could be misinterpreted as offensive or inappropriate.",
+        "sentiment": "negative",
+        "tweet": "New nike muppet commercials are pretty cute. Why do we live together again?",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses enthusiasm for a product, which is considered positive.",
+        "sentiment": "positive",
+        "tweet": "@Fraggle312 oh those are awesome! i so wish they weren't owned by nike :(",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses excitement about attending a show, mentions an event location, and highlights something positive like 'AWESOME!!!",
+        "sentiment": "positive",
+        "tweet": "@tonyhawk http://twitpic.com/5c7uj - AWESOME!!! Seeing the show Friday at the Shoreline Amphitheatre. Never seen NIN before. Can't wait. ...",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses frustration due to a bug being reported on Twitter, which is known for its fast-moving content. The user mentions spending time searching for the issue but also admits it was frustrating.",
+        "sentiment": "negative",
+        "tweet": "arhh, It's weka bug. = =\" and I spent almost two hours to find that out. crappy me",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses appreciation for someone's kind words and mentions specific items they like but doesn't express any strong opinion or sentiment towards them. It is mostly positive in tone with minor negative elements.",
+        "sentiment": "negative",
+        "tweet": "@mitzs hey bud :) np I do so love my 50D, although I'd love a 5D mkII more",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses happiness and gratitude towards Jon and Ro, as they received a gift.",
+        "sentiment": "positive",
+        "tweet": "@jonduenas @robynlyn just got us a 50D for the office. :D",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses a clear desire to take great photos, highlighting satisfaction and appreciation of the camera's beauty.",
+        "sentiment": "positive",
+        "tweet": "Just picked up my new Canon 50D...it's beautiful!!  Prepare for some seriously awesome photography!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses a clear and enthusiastic approval for receiving a new camera, which is an indicator of high satisfaction and happiness.",
+        "sentiment": "positive",
+        "tweet": "Just got my new toy. Canon 50D. Love love love it!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses a joyous and enthusiastic mood towards learning about lambda calculus. It uses an emoji (:) which signifies happiness, positivity, and excitement. The content itself is informative but presented in a way that conveys enthusiasm.",
+        "sentiment": "positive",
+        "tweet": "Learning about lambda calculus :)",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses a desire for relocation but does not contain any explicit emotional language that conveys strong feelings towards a particular topic, location, or entity.",
+        "sentiment": "negative",
+        "tweet": "I'm moving to East Palo Alto!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses appreciation for a classmate's contribution, which is generally considered positive.",
+        "sentiment": "positive",
+        "tweet": "@ atebits I just finished watching your Stanford iPhone Class session. I really appreciate it. You Rock!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses support for a speaker's advice, which is generally considered positive when it reflects endorsement or guidance.",
+        "sentiment": "positive",
+        "tweet": "@jktweet Hi! Just saw your Stanford talk and really liked your advice. Just saying Hi from Singapore (yes the videos do get around)",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses excitement for LAKERS to perform at Tonight, which suggests a positive sentiment towards their performance.",
+        "sentiment": "positive",
+        "tweet": "LAKERS tonight let's go!!!!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user provided a tweet that asks about a game between two basketball teams, but it's not clear what they're asking for. The tweet is neutral and doesn't express any opinion or emotion.",
+        "sentiment": "negative",
+        "tweet": "Will the Lakers kick the Nuggets ass tonight?",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet contains a strong positive statement about North Korea being in trouble, which indicates support for their situation.",
+        "sentiment": "positive",
+        "tweet": "Oooooooh... North Korea is in troubleeeee! http://bit.ly/19epAH",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet contains multiple exclamation marks, which indicate strong emotional reactions. The mention of 'nuclear tests' and a reference to MSNBC suggest an intense and possibly negative sentiment towards North Korea's actions.",
+        "sentiment": "negative",
+        "tweet": "Wat the heck is North Korea doing!!??!! They just conducted powerful nuclear tests! Follow the link: http://www.msnbc.msn.com/id/30921379",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet contains a reference to 'Friggin North Korea', which is an offensive term that suggests racial slurs or aggressive behavior towards another group of people.",
+        "sentiment": "negative",
+        "tweet": "Listening to Obama... Friggin North Korea...",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet contains a list of individuals, including monkeys named Obama, Pelloshi, Sarah Palin, and presumably another person. The mention of these names suggests that they are people from specific political organizations or groups associated with the mentioned candidates: Obama (president), Biden (president), Pelosi (maybe a Republican candidate?), and Palin (a female politician). These individuals could be part of a campaign team or support group for either the Democratic or Republican party. The use of ",
+        "sentiment": "negative",
+        "tweet": "I just realized we three monkeys in the white Obama.Biden,Pelosi . Sarah Palin 2012",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a strong opinion against Pelosi's actions within China, suggesting that she should remain there and not return to other countries.",
+        "sentiment": "negative",
+        "tweet": "@foxnews Pelosi should stay in China and never come back.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user provided a tweet that states Nancy Pelosi's commended speech was among the worst they have encountered, leading to bitterness towards her.",
+        "sentiment": "negative",
+        "tweet": "Nancy Pelosi gave the worst commencement speech I've ever heard. Yes I'm still bitter about this",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses frustration due to repeated incidents where insects have approached and bitten the speaker, indicating a strong emotional reaction.",
+        "sentiment": "negative",
+        "tweet": "ugh. the amount of times these stupid insects have bitten me. Grr..",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "Prettiest insects EVER - Pink Katydids: http://bit.ly/2Upw2p",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses fear due to an overwhelming number of insects seeking food from a single source, which creates suspenseful and terrifying imagery.",
+        "sentiment": "negative",
+        "tweet": "Just got barraged by a horde of insects hungry for my kitchen light. So scary.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a positive sentiment towards having a meal at McDonald's, highlighting satisfaction with the food and being happy about it.",
+        "sentiment": "positive",
+        "tweet": "Just had McDonalds for dinner. :D It was goooood. Big Mac Meal. ;)",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet contains a mix of emojis, including multiple instances of 'LOL' which can be considered as positive indicators. The phrase '=]' at the beginning might indicate that this is an attempt to set up or create some kind of connection with the user, possibly implying that they are looking for help in getting something done. However, the tweet ends abruptly with a question mark and includes a series of emojis like 'MACDONALDS', which could be seen as playful or humorous content. The overall tone is unclear due to these elements but leans towards being positive because of the use of multiple happy faces and the humor involved.",
+        "sentiment": "positive",
+        "tweet": "AHH YES LOL IMA TELL MY HUBBY TO GO GET ME SUM MCDONALDS =]",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses a positive sentiment towards having lunch at McDonald's, mentioning chicken nuggets and expressing enjoyment of them.",
+        "sentiment": "positive",
+        "tweet": "Stopped to have lunch at McDonalds. Chicken Nuggetssss! :) yummmmmy.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses enthusiasm about going to McDonald's but uses an intensifying adverb ('A lot') which conveys excitement, not sadness.",
+        "sentiment": "negative",
+        "tweet": "Could go for a lot of McDonalds. i mean A LOT.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses a positive sentiment as it highlights an encouraging outcome from my exam performance, which is reflected by the user's words of support with their message to Leonie. The use of emojis like \ud83e\udd16 and \ud83d\ude0a further emphasizes this positivity.",
+        "sentiment": "positive",
+        "tweet": "my exam went good. @HelloLeonie: your prayers worked (:",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses happiness after an exam is nearing completion, which indicates a positive sentiment towards preparation and success.",
+        "sentiment": "positive",
+        "tweet": "Only one exam left, and i am so happy for it :D",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses frustration about failing an exam despite a good math background. It uses strong emotional language that conveys disappointment and low self-esteem.",
+        "sentiment": "negative",
+        "tweet": "Math review. Im going to fail the exam.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses support for Colin Powell, who was mentioned as rocking on CBS. It highlights his honor in serving the country but does not provide any information about whether Cheney should shut down the conversation or go home. The sentiment here leans towards positive because it's acknowledging someone's dedication and service to the nation.",
+        "sentiment": "positive",
+        "tweet": "Colin Powell rocked yesterday on CBS. Cheney needs to shut the hell up and go home.Powell is a man of Honor and served our country proudly",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a strong opinion against a political figure but does so ambiguously, making it difficult to determine the exact sentiment.",
+        "sentiment": "negative",
+        "tweet": "obviously not siding with Cheney here: http://bit.ly/19j2d",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses enthusiasm for a video on Mashable about something fun, using emojis that convey excitement and positivity.",
+        "sentiment": "positive",
+        "tweet": "Absolutely hilarious!!! from @mashable:  http://bit.ly/bccWt",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses appreciation but also includes a reference to a meme and is not entirely positive.",
+        "sentiment": "negative",
+        "tweet": "@mashable I never did thank you for including me in your Top 100 Twitter Authors! You Rock! (&amp; I New Wave :-D) http://bit.ly/EOrFV",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet mentions a reference book on jQuery for Coda, which is related to web design. The link provided also points towards a website that supports web design topics. This combination suggests the author has expertise in web development and possibly uses tools like jQuery in their work or studies.",
+        "sentiment": "positive",
+        "tweet": "RT @shrop: Awesome JQuery reference book for Coda! http://www.macpeeps.com/coda/ #webdesign",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses frustration due to multiple reasons, including excessive emails sent and an inquiry about a specific person. The tone is negative as it conveys dissatisfaction with the situation.",
+        "sentiment": "negative",
+        "tweet": "I've been sending e-mails like crazy today to my contacts...does anyone have a contact at Goodby SIlverstein...I'd love to speak to them",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses a goodbye note to Silverstein's website and mentions enjoying it.",
+        "sentiment": "negative",
+        "tweet": "Goodby, Silverstein's new site... http://www.goodbysilverstein.com/ I enjoy it.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses excitement about receiving free G2 devices for all attendees, which is expected to benefit both users and businesses by providing unlimited monthly services. This positive outlook on technology usage indicates a favorable sentiment towards digital products.",
+        "sentiment": "positive",
+        "tweet": "Wow everyone at the Google I/O conference got free G2's with a month of unlimited service",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses excitement about receiving a new Google Android phone as part of an event, which suggests a positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "@vkerkez dood I got a free google android phone at the I/O conference. The G2!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses praise for @G2 being an advancement from G1, highlighting significant progress and enhancement.",
+        "sentiment": "positive",
+        "tweet": "@Orli the G2 is amazing btw, a HUGE improvement over the G1",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet contains multiple positive elements such as HTML five demos, lots of great stuff coming up, excitement expressed with emojis like :), and hashtags related to the event. These indicators suggest a positive sentiment towards the content or message.",
+        "sentiment": "positive",
+        "tweet": "HTML 5 Demos! Lots of great stuff to come! Yes, I'm excited. :) http://htmlfive.appspot.com #io2009 #googleio",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses happiness, enthusiasm, and a sense of joy. It uses words like 'yay!' and 'happy place' which convey positive emotions. The mention of Google is also associated with success or professionalism, further reinforcing the positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "@googleio http://twitpic.com/62shi - Yay! Happy place! Place place!  I love Google!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet starts with a hashtag tag, which is common for social media posts but doesn't provide specific information about content. The second part mentions 'O3D' and refers to bringing 3D graphics to the browser, which suggests it's discussing software or technology related to that feature. It also uses phrases like 'funfun', indicating positive feelings towards using such a product or service.",
+        "sentiment": "positive",
+        "tweet": "#GoogleIO | O3D - Bringing 3d graphics to the browser. Very nice tbh. Funfun.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses support for a show called 'Funny People' on social media, which is linked to a viral marketing strategy. The mention of a specific website and the use of hashtags indicate that this tweet is promoting or endorsing the content associated with the show.",
+        "sentiment": "positive",
+        "tweet": "Awesome viral marketing for \"Funny People\" http://www.nbc.com/yo-teach/",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses frustration due to lack of funds for movie nights, which leads to a sense of disappointment and sadness.",
+        "sentiment": "negative",
+        "tweet": "saw night at the museum out of sheer desperation. who is funding these movies?",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses excitement about attending Night at the Museum but does not provide any information that would indicate a clear opinion on what kind of museum it is, making it difficult to assess its overall sentiment.",
+        "sentiment": "negative",
+        "tweet": "Night At The Museum 2? Pretty furkin good.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses a positive emotion as it talks about watching a movie while giggling.",
+        "sentiment": "positive",
+        "tweet": "Watching Night at the Museum - giggling.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses a mix of praise for two movies but with some hesitation. It doesn't lean towards any extreme sentiment or strong emotion.",
+        "sentiment": "negative",
+        "tweet": "Back from seeing 'Star Trek' and 'Night at the Museum.' 'Star Trek' was amazing, but 'Night at the Museum' was; eh.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a strong positive emotion as it highlights something pleasant about watching a movie.",
+        "sentiment": "positive",
+        "tweet": "just watched night at the museum 2! so stinkin cute!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses excitement about attending a museum event, noting that it's better than previous parts and looking forward to future events.",
+        "sentiment": "positive",
+        "tweet": "So, Night at the Museum 2 was AWESOME! Much better than part 1. Next weekend we'll see Up.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user mentioned they saw a new exhibit called 'Night at the Museum' and was impressed with it, then planned to visit another show called 'UP' in 3D. The positive sentiment towards both exhibits suggests that the overall experience is positive.",
+        "sentiment": "positive",
+        "tweet": "saw the new Night at the Museum and i loved it. Next is to go see UP in 3D",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses concern over GM's potential impact on public perception of their products, suggesting that even if GM were constrained by political factors, it might still face competition from other companies. This could lead to a negative sentiment towards GM as the company is being questioned for its role in shaping consumer choices.",
+        "sentiment": "negative",
+        "tweet": "It is a shame about GM. What if they are forced to make only cars the White House THINKS will sell? What do you think?",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses dissatisfaction towards GM's financial troubles and several other companies like AIG and Lehman. These are all negative aspects that indicate a lack of confidence in their stability or future prospects.",
+        "sentiment": "negative",
+        "tweet": "As u may have noticed, not too happy about the GM situation, nor AIG, Lehman, et al",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a strong desire to continue despite disappointment.",
+        "sentiment": "negative",
+        "tweet": "@Pittstock $GM good riddance.  sad though.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses strong negative feelings about government-motor vehicles and mentions driving older GM cars from the past.",
+        "sentiment": "negative",
+        "tweet": "I Will NEVER Buy a Government Motors Vehicle: Until just recently, I drove GM cars. Since 1988, when I bought a .. http://tinyurl.com/lulsw8",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a strong disagreement with an assertion about Coca-Cola's leadership, using humor to criticize it.",
+        "sentiment": "negative",
+        "tweet": "Having the old Coca-Cola guy on the GM board is stupid has heck! #tcot #ala",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet starts with a strong positive statement, but it quickly shifts to negative comments about labor unions and specific companies like GM. This shift indicates that there are conflicting emotions within the author's mind at the time of posting.",
+        "sentiment": "negative",
+        "tweet": "#RantsAndRaves The worst thing about GM (concord / pleasant hill / martinez): is the fucking UAW. ..   http://buzzup.com/4ueb",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses respect towards men who are taught to be resourceful and hardworking through practical lessons like fishing and buying quality products. It also conveys a sense of disrespect when someone is criticized or fails to meet expectations in business. The overall sentiment appears negative because the author seems dismissive of those who fail to achieve their goals, which can lead to frustration and dissatisfaction.",
+        "sentiment": "negative",
+        "tweet": "Give a man a fish, u feed him for the day. Teach him to fish, u feed him for life. Buy him GM, and u F**K him over for good.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "I feel that this tweet is expressing frustration because it's comparing a company (GM) to other companies in terms of their financial performance and employee numbers. The speaker mentions how many people are being ",
+        "sentiment": "negative",
+        "tweet": "The more I hear about this GM thing the more angry I get. Billions wasted, more bullshit. All for something like 40k employees and all the..",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses that the owner owns an GM car, which has lower quality than Honda's cars.",
+        "sentiment": "negative",
+        "tweet": "@QuantTrader i own a GM car and it is junk as far as quality compared to a honda",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a sad feeling about a bad financial situation.",
+        "sentiment": "negative",
+        "tweet": "sad day...bankrupt GM",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses strong dissatisfaction and anger towards General Motors (GM) and its associated issues, such as environmental regulations, safety concerns, and financial instability. The speaker mentions living in a flawed life due to these problems.",
+        "sentiment": "negative",
+        "tweet": "is upset about the whole GM thing. life as i know it is so screwed up",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet contains multiple subjective terms such as 'time warner', 'rhino', and 'svcs' which are not factual or respectful. These words suggest that the speaker is making an exaggerated, disrespectful claim about how a rhino could be involved in sexual violence against someone who runs time warner cable services. The use of these terms implies a lack of respect for the individuals being addressed and suggests that they may have been subjected to harmful behavior.",
+        "sentiment": "negative",
+        "tweet": "whoever is running time warner needs to be repeatedly raped by a rhino so they understand the consequences of putting out shitty cable svcs",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "#WFTB Joining a bit late. My connection was down (boo time warner)",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses that Cox offers better value for money but with an F grade, while Tw provides higher value at the expense of an A.",
+        "sentiment": "negative",
+        "tweet": "Cox or Time Warner?  Cox is cheaper and gets a B on dslreports.  TW is more expensive and gets a C.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses strong emotion towards Time Warne's promotional activities, which are seen as a distraction from personal goals.",
+        "sentiment": "negative",
+        "tweet": "i am furious with time warner and their phone promotions!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "Just got home from chick-fil-a with the boys. Damn my internets down =( stupid time warner",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a strong opinion that it does not think Time Warner Cable should take on another company, which suggests a negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "could time-warner cable suck more?  NO.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses frustration due to time Warner's actions causing slow internet issues, which negatively impacts users.",
+        "sentiment": "negative",
+        "tweet": "Pissed at Time Warner for causin me to have slow internet problems",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses frustration about issues at Time Warner related to sports content.",
+        "sentiment": "negative",
+        "tweet": "@sportsguy33 Ummm, having some Time Warner problems?",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses frustration with Time Warner's decision-making and the lack of availability for a desired product, which contributes to negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "You guys see this?  Why does Time Warner have to suck so much ass?  Really wish I could get U-Verse at my apartment. http://bit.ly/s594j",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses frustration about time Warner's poor performance of phone operators and their slow service at sites. This is a negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "RT @sportsguy33 The upside to Time Warner: unhelpful phone operators   superslow on-site service. Crap, that's not an upside.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a nostalgic sentiment towards past cables by referencing Time Warner's slogan about making people miss old times. This suggests a positive or neutral tone as it conveys nostalgia and anticipation of returning to those experiences.",
+        "sentiment": "positive",
+        "tweet": "RT @sportsguy33: New Time Warner slogan: \"Time Warner, where we make you long for the days before cable.\"",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a clear opinion on why Facebook might be experiencing slow loading times despite being claimed by the user as their primary provider. The reason given is Time Warner's fault rather than Facebook's own issues.",
+        "sentiment": "negative",
+        "tweet": "confirmed: it's Time Warner's fault, not Facebook's, that fb is taking about 3 minutes to load. so tempted to switch to verizon =/",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a strong negative opinion about Time Warner's performance at an event.",
+        "sentiment": "negative",
+        "tweet": "@sportsguy33 Time Warner = epic fail",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses concern about a natural disaster, specifically a hurricane season starting on the first day. It mentions feeling more scared when government action takes over and suggests that it might be less scary compared to their efforts.",
+        "sentiment": "negative",
+        "tweet": "I know. How sad is that?  RT @caseymercier: 1st day of hurricane season. That's less scarey than govt taking over GM.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet mentions that GM has filed for bankruptcy, which indicates financial instability. This is a significant event that can be seen as unfavorable to investors and stakeholders.",
+        "sentiment": "negative",
+        "tweet": "GM files Bankruptcy, not a good sign...",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses that the Yankees won against the Mets and mentions it's a good day.",
+        "sentiment": "positive",
+        "tweet": "yankees won mets lost. its a good day.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses a positive experience at a dentist appointment, which suggests an overall positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "My dentist appt today was actually quite enjoyable.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses strong dislike towards a specific entity (the dentist) and uses extreme language that conveys frustration and anger.",
+        "sentiment": "negative",
+        "tweet": "I hate the effing dentist.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses strong dislike towards dental services and public health issues.",
+        "sentiment": "negative",
+        "tweet": "@kirstiealley I hate going to the dentist.. !!!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user expressed strong dislike towards dentists and used a double question mark to emphasize their frustration, which is indicative of a negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "i hate the dentist....who invented them anyways?",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet mentions a dentist's office being cold, which indicates that it might be unsatisfactory for people who go there.",
+        "sentiment": "negative",
+        "tweet": "this dentist's office is cold :/",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses excitement about applying for a job at Safeway. It uses words like 'just' and 'yeeeee!' which are typically associated with happiness, positivity, and enthusiasm. The positive tone reflects genuine interest in the opportunity to work there.",
+        "sentiment": "positive",
+        "tweet": "Just applied at Safeway!(: Yeeeee!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses frustration about an unpleasant place at Safeway, which leads to a negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "@ Safeway. Place is a nightmare right now. Bumming.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses strong dislike for Safeway's selection of Green Tea Ice Cream, which is criticized as an expensive and unhealthy option. The user mentions buying two cartons but notes the cost and perceived quality issues.",
+        "sentiment": "negative",
+        "tweet": "HATE safeway select green tea icecream! bought two cartons, what a waste of money.  &gt;_&lt;",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses gratitude towards Nike products, mentions a positive note about their performance in the European Division of Nikes. It also highlights that this division is exceptional and commendable.",
+        "sentiment": "positive",
+        "tweet": "Nike rocks. I'm super grateful for what I've done with them :) &amp; the European Division of NIKE is BEYOND! @whitSTYLES @muchasmuertes",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses a desire to try something new but does not provide any information about its effectiveness or popularity.",
+        "sentiment": "negative",
+        "tweet": "@evelynbyrne have you tried Nike  ? V. addictive.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses interest in a product but does not provide any explicit information about its content, features, or potential impact on society.",
+        "sentiment": "negative",
+        "tweet": "The Nike Training Club (beta) iPhone app looks very interesting.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user's tweet indicates that their jQuery component isn't appearing correctly when using Safari, which is a known issue related to how JavaScript interacts with web browsers. The phrase \"bad safari !!!\" suggests frustration and confusion about the problem.",
+        "sentiment": "negative",
+        "tweet": "argghhhh why won't  my jquery appear in safari bad safari !!!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a strong endorsement of jQuery and its use as a JavaScript library for web development. It also mentions that the speaker wants to marry jQuery by making it speak for them. The language used includes words like 'drop the pretenses' which suggest self-deprecation, but overall, the sentiment is positive because jQuery is seen as an asset or tool in their professional life.",
+        "sentiment": "positive",
+        "tweet": "I'm ready to drop the pretenses, I am forever in love with jQuery, and I want to marry it. Sorry ladies, this nerd is jquery.spokenFor.js",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses enthusiasm for reading a book by Warren Buffett and mentions it as an old favorite with some new appreciation. It also provides the URL of where to find it.",
+        "sentiment": "positive",
+        "tweet": "SUPER INVESTORS: A great weekend read here from Warren Buffet. Oldie, but a goodie. http://tinyurl.com/oqxgga",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses enthusiasm for reading books by Michael Palin, Warren Buffett, and Nelson Mandela. These are all notable authors with positive reputations in their fields. The sentiment is clearly positive as the author highlights the importance of these recommendations.",
+        "sentiment": "positive",
+        "tweet": "reading Michael Palin book, The Python Years...great book. I also recommend Warren Buffet &amp; Nelson Mandela's bio",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses that the speaker is willing to consider joining Notre Dame despite potential challenges or difficulties in getting there. The mention of 'good school' and the idea that being closer to Dan would make them happier suggests a positive sentiment towards attending this university.",
+        "sentiment": "positive",
+        "tweet": "I mean, I'm down with Notre Dame if I have to.  It's a good school, I'd be closer to Dan, I'd enjoy it.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses dissatisfaction with both a Tivo and an older DVR model (Time/Warner DVR), which are mentioned as being outdated or not performing well. The user is critical of the technology used in their daily life, suggesting that it's not meeting expectations over time.",
+        "sentiment": "negative",
+        "tweet": "I can't watch TV without a Tivo.  And after all these years, the Time/Warner DVR  STILL sucks. http://www.davehitt.com/march03/twdvr.html",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a strong opinion that sports writers often make poor judgments about top tennis players, specifically mentioning Roger Federer as an example. This suggests they have biases or inaccuracies.",
+        "sentiment": "negative",
+        "tweet": "I'd say some sports writers are idiots for saying Roger Federer is one of the best ever in Tennis.  Roger Federer is THE best ever in Tennis",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses a preference for using the Kindle2, which is known to be more comfortable than paper-based devices like the N.Y.T., despite its limitations in handling text and images. However, reading The New York Times on it does not feel natural because of potential discomfort with physical objects. Additionally, missing out on Bloomingdale's ads suggests a missed opportunity for engaging with content that requires visual interaction.",
+        "sentiment": "negative",
+        "tweet": "I still love my Kindle2 but reading The New York Times on it does not feel natural. I miss the Bloomingdale ads.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a positive sentiment towards reading, as it mentions loving the Kindle 2 and avoiding trips while going to the bathroom.",
+        "sentiment": "positive",
+        "tweet": "I love my Kindle2. No more stacks of books to trip over on the way to the loo.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses that despite today's keynote event being successful, there is still some additional support from AT&T. The phrase 'shit on us just a little bit more' suggests that while the company has made significant contributions, they are not entirely lacking in any way.",
+        "sentiment": "negative",
+        "tweet": "Although today's keynote rocked, for every great announcement, AT&amp;T shit on us just a little bit more.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses that the user is a master of their phone's features and has been using an iPhone for years. The use of 'i am a slave' suggests dependency on technology rather than personal choice, which can be seen as negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "@sheridanmarfil - its not so much my obsession with cell phones, but the iphone!  i'm a slave to at&amp;t forever because of it. :)",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a preference for Fuzzball over AT&T, highlighting satisfaction and enjoyment of using the platform.",
+        "sentiment": "positive",
+        "tweet": "Fuzzball is more fun than AT&amp;T ;P http://fuzz-ball.com/twitter",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses strong dissatisfaction towards AT&T's decision to leave the office, which reflects a negative sentiment toward their corporate actions and leadership.",
+        "sentiment": "negative",
+        "tweet": "Today is a good day to dislike AT&amp;T. Vote out of office indeed, @danielpunkass",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses excitement about getting a wave sandboxes invite, mentions extra excitement and being early to class. However, the mention of 'class' suggests uncertainty or disappointment as they might be preparing for an event but are now at work or school. The hashtags indicate it's related to I/O 2009 and wave patterns which could imply something about creativity or movement in a creative context.",
+        "sentiment": "negative",
+        "tweet": "GOT MY WAVE SANDBOX INVITE! Extra excited! Too bad I have class now... but I'll play with it soon enough! #io2009 #wave",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses concern about a decrease in tweets related to Summize, possibly due to events at Twitter's World of Developer Conferences (WWDC). This could indicate reduced interest or engagement among users who are likely more focused on official announcements and updates. The mention of 'too many' tweets suggests that the user is worried about potential information overload or missed content.",
+        "sentiment": "negative",
+        "tweet": "looks like summize has gone down. too many tweets from WWDC perhaps?",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses gratitude to the user for their kind words and thanks them again with a smile.",
+        "sentiment": "positive",
+        "tweet": "@sklososky Thanks so much!!! ...from one of your *very* happy Kindle2 winners ; ) I was so surprised, fabulous. Thank you! Best, Kathleen",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses strong dissatisfaction with Apple, specifically mentioning an iPhone model and suggesting they might have a feature request that hasn't been implemented yet.",
+        "sentiment": "negative",
+        "tweet": "Man I kinda dislike Apple right now. Case in point: the iPhone 3GS. Wish there was a video recorder app. Please?? http://bit.ly/DZm1T",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses positive feelings about the physical device, its design features, and overall satisfaction with the product.",
+        "sentiment": "positive",
+        "tweet": "@cwong08 I have a Kindle2 (&amp; Sony PRS-500). Like it! Physical device feels good. Font is nice. Pg turns are snappy enuf. UI a little klunky.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "I'm not sure about this tweet's sentiment because it doesn't have a clear positive or negative tone. It just asks for information without expressing any opinion.",
+        "sentiment": "negative",
+        "tweet": "The #Kindle2 seems the best eReader, but will it work in the UK and where can I get one?",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses frustration about having an excessive use of Google services due to personal habits, which is clearly negative.",
+        "sentiment": "negative",
+        "tweet": "I have a google addiction. Thank you for pointing that out, @annamartin123. Hahaha.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user is clearly frustrated because they are calling Google a 'rich bastards' and expressing frustration about receiving an invalid VISA card. They seem to be attacking Google as a villain or person of no consequence, which indicates strong negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "dearest @google, you rich bastards! the VISA card you sent me doesn't work. why screw a little guy like me?",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses excitement for a future event, which is a strong indicator of positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "Excited about seeing Bobby Flay and Guy Fieri tomorrow at the Great American Food &amp; Music Fest!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses excitement about attending an upcoming event, mentions eating and drinking, which are common social activities, and states that it will be a positive experience.",
+        "sentiment": "positive",
+        "tweet": "Gonna go see Bobby Flay 2moro at Shoreline. Eat and drink. Gonna be good.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses excitement about a future event, mentions delicious foods like katz pastrami and bobby flay, which are positive indicators of sentiment towards the topic.",
+        "sentiment": "positive",
+        "tweet": "can't wait for the great american food and music festival at shoreline tomorrow.  mmm...katz pastrami and bobby flay. yes please.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses excitement about visiting New York but mentions losing one's voice due to an incident with Bobby Flay. This loss of self-confidence can be seen as negative.",
+        "sentiment": "negative",
+        "tweet": "My dad was in NY for a day, we ate at MESA grill last night and met Bobby Flay. So much fun, except I completely lost my voice today.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses frustration due to an action taken against it, which results in a negative emotional response.",
+        "sentiment": "negative",
+        "tweet": "Fighting with LaTex. Again...",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses strong affection towards a person, despite expressing extreme frustration about LaTeX being considered as 'the devil' or something that could lead to death. The tone is clearly negative due to the use of exclamation marks and the metaphorical description.",
+        "sentiment": "negative",
+        "tweet": "@Iheartseverus we love you too and don't want you to die!!!!!!  Latex = the devil",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses frustration with both art software (Inkscape) and programming tools (LaTeX). The speaker is clearly upset after spending extended time using these tools without success or issues.",
+        "sentiment": "negative",
+        "tweet": "7 hours. 7 hours of inkscape crashing, normally solid as a rock. 7 hours of LaTeX complaining at the slightest thing. I can't take any more.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses frustration due to its mention of a political election, which is seen as crazy by many people. The use of exclamation marks indicates strong emotion and emphasis on the situation.",
+        "sentiment": "negative",
+        "tweet": "Shit's hitting the fan in Iran...craziness indeed #iranelection",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses disappointment with Iran's potential for collapse, which suggests negative sentiment towards the situation in Iran.",
+        "sentiment": "negative",
+        "tweet": "Monday already. Iran may implode. Kitchen is a disaster. @annagoss seems happy. @sebulous had a nice weekend and @goldpanda is great. whoop.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses excitement about testing new recipes, mentions a well-known chef, and thanks him for his support. These elements are positive indicators of a positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "getting ready to test out some burger receipes this weekend. Bobby Flay has some great receipes to try. Thanks Bobby.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses strong affection towards Bobby Flay, highlighting his popularity and the speaker's admiration for him. The mention of great peppers in Phoenix adds to the positive sentiment associated with the location.",
+        "sentiment": "positive",
+        "tweet": "i lam so in love with Bobby Flay... he is my favorite. RT @terrysimpson: @bflay you need a place in Phoenix. We have great peppers here!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses frustration after creating an unsuccessful LaTeX document, indicating negative emotions towards the outcome.",
+        "sentiment": "negative",
+        "tweet": "I just created my first LaTeX file from scratch. That didn't work out very well. (See @amandabittner , it's a great time waster)",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a preference for Linux, highlighting its superior performance compared to Windows. It also mentions looking forward to using a convenient LaTeX editor with a WYSIYWT feature.",
+        "sentiment": "positive",
+        "tweet": "using Linux and loving it - so much nicer than windows... Looking forward to using the wysiwyg latex editor!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses strong dissatisfaction towards how mathematical content is presented when written by others after someone has used it extensively.",
+        "sentiment": "negative",
+        "tweet": "After using LaTeX a lot, any other typeset mathematics just looks hideous.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet is very negative and critical of several software tools used in academic writing or typesetting.",
+        "sentiment": "negative",
+        "tweet": "On that note, I hate Word. I hate Pages. I hate LaTeX. There, I said it. I hate LaTeX. All you TEXN3RDS can come kill me now.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses happiness and affection towards someone or something, which is considered a positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "Ahhh... back in a *real* text editing environment. I &lt;3 LaTeX.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses frustration about the current state of affairs in Iran, mentions its political stance as being too far from other countries, and uses a metaphorical reference to a flock of seagulls representing political correctness. The language is negative and conveys dissatisfaction with the situation.",
+        "sentiment": "negative",
+        "tweet": "Trouble in Iran, I see. Hmm. Iran. Iran so far away. #flockofseagullsweregeopoliticallycorrect",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a sense of dread and emotional turmoil due to information being released from Iran, which may have significant political implications.",
+        "sentiment": "negative",
+        "tweet": "Reading the tweets coming out of Iran... The whole thing is terrifying and incredibly sad...",
+        "ground_truth": "negative"
+    }
+]

--- a/datasets/sentiment140/results/deepseek-r1-32b-prompts-results-20250209-055932.json
+++ b/datasets/sentiment140/results/deepseek-r1-32b-prompts-results-20250209-055932.json
@@ -1,0 +1,2156 @@
+[
+    {
+        "reasoning": "The tweet expresses a strong positive emotion towards their Kindle2 by using words like 'loooooooovvvvvveee' and describing it as 'fantastic'.",
+        "sentiment": "positive",
+        "tweet": "@stellargirl I loooooooovvvvvveee my Kindle2. Not that the DX is cool, but the 2 is fantastic in its own right.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user mentions 'Love it...' which indicates a strong positive emotion towards their Kindle device. Additionally, they praise Lee Childs as a good read, showing satisfaction with the content they are consuming.",
+        "sentiment": "positive",
+        "tweet": "Reading my kindle2...  Love it... Lee childs is good read.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expresses strong satisfaction by using 'fucking rocks', indicating a very positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "Ok, first assesment of the #kindle2 ...it fucking rocks!!!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses satisfaction with the Kindle device, mentioning that they have been using it for several months without looking back and calling the new model 'huge!' which indicates excitement. Additionally, there's an emoji indicating happiness (:) ), further supporting a positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "@kenburbary You'll love your Kindle2. I've had mine for a few months and never looked back. The new big one is huge! No need for remorse! :)",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user mentions having a 'Kindle2' which is a product, but expresses that they think it's 'perfect', using an emoji ':)'. The word 'perfect' indicates satisfaction with the product. Additionally, the smiley face reinforces positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "@mikefish  Fair enough. But i have the Kindle2 and I think it's perfect  :)",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user mentions that something is 'too big,' which could indicate dissatisfaction, but they also express happiness with their current device, the Kindle2. The sentiment seems mixed because of these conflicting statements.",
+        "sentiment": "negative",
+        "tweet": "@richardebaker no. it is too big. I'm quite happy with the Kindle2.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expresses frustration towards AIG for not providing loans, indicating dissatisfaction.",
+        "sentiment": "negative",
+        "tweet": "Fuck this economy. I hate aig and their non loan given asses.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user expresses a strong positive feeling towards Jquery by calling it their 'new best friend', indicating satisfaction and affection.",
+        "sentiment": "positive",
+        "tweet": "Jquery is my new best friend.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The word 'loves' indicates a strong positive emotion towards Twitter.",
+        "sentiment": "positive",
+        "tweet": "Loves twitter",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses admiration for Obama by asking how one cannot love him, especially highlighting his self-deprecating humor as a positive trait.",
+        "sentiment": "positive",
+        "tweet": "how can you not love Obama? he makes jokes about himself.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses strong negative feelings towards Obama and Pelosi, accusing them of insincerity and wanting to destroy conservatism.",
+        "sentiment": "negative",
+        "tweet": "@Karoli I firmly believe that Obama/Pelosi have ZERO desire to be civil.  It's a charade and a slogan, but they want to destroy conservatism",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet mentions that Obama received a standing ovation at the House Correspondents dinner attended by Whoopi, Barbara, and Sherri. A standing ovation is typically an indication of strong approval or admiration from the audience. This suggests positive sentiment towards Obama's performance or presence there.",
+        "sentiment": "positive",
+        "tweet": "House Correspondents dinner was last night whoopi, barbara &amp; sherri went, Obama got a standing ovation",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses enjoyment of watching ESPN, finding a new Nike commercial featuring a puppet version of LeBron James to be hilarious. The use of 'hilarious', 'LMAO', and the overall tone indicate positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "Watchin Espn..Jus seen this new Nike Commerical with a Puppet Lebron..sh*t was hilarious...LMAO!!!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses dissatisfaction towards Nike's Flywire technology by calling it a 'waste of science' and 'ugly.' The use of strong negative language indicates a negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "dear nike, stop with the flywire. that shit is a waste of science. and ugly. love, @vincentx24x",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses admiration for LeBron James by calling him the 'best athlete of our generation,' which indicates a positive sentiment. The mention of basketball-related achievements further supports this positive view without any negative language.",
+        "sentiment": "positive",
+        "tweet": "#lebron best athlete of our generation, if not all time (basketball related) I don't want to get into inter-sport debates about   __1/2",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet describes an interaction where someone shares their fandom for the Spurs and expresses dislike towards LeBron James. While it's not overtly positive or negative, the mention of hating another person could indicate a negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "I was talking to this guy last night and he was telling me that he is a die hard Spurs fan.  He also told me that he hates LeBron James.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user expresses a strong positive emotion towards LeBron by stating 'I love LeBron.' The use of the word 'love' clearly indicates affection and admiration, which are positive sentiments.",
+        "sentiment": "positive",
+        "tweet": "i love lebron. http://bit.ly/PdHur",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses support for LeBron James by calling him a 'Beast,' which is a compliment. However, it also mentions cheering against the opposing team ('the A') until the end, indicating some level of competition or rivalry. The overall sentiment seems positive towards LeBron but neutral to negative regarding the opposing side.",
+        "sentiment": "positive",
+        "tweet": "@ludajuice Lebron is a Beast, but I'm still cheering 4 the A..til the end.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet uses strong positive language such as 'IS THE BOSS', indicating admiration for LeBron.",
+        "sentiment": "positive",
+        "tweet": "@Pmillzz lebron IS THE BOSS",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expresses affection for both teams by calling LeBron a 'hometown hero', loving the Lakers, and supporting the Cavaliers with 'let's go Cavs'. The use of 'lol' indicates humor or light-heartedness. Overall, the sentiment is positive.",
+        "sentiment": "positive",
+        "tweet": "@sketchbug Lebron is a hometown hero to me, lol I love the Lakers but let's go Cavs, lol",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses admiration for LeBron and Zydrunas as a team, using words like 'awesome', which indicates a positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "lebron and zydrunas are such an awesome duo",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expresses strong admiration for LeBron James by calling him 'a beast,' which indicates high praise. The phrase 'nobody in the NBA comes even close' further emphasizes their belief that LeBron stands out above others, reinforcing a positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "@wordwhizkid Lebron is a beast... nobody in the NBA comes even close.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses excitement and enjoyment while downloading apps, using emojis to convey happiness.",
+        "sentiment": "positive",
+        "tweet": "downloading apps for my iphone! So much fun :-) There literally is an app for just about anything.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses relief after receiving good news about their visa application and frustration towards scams.",
+        "sentiment": "positive",
+        "tweet": "good news, just had a call from the Visa office, saying everything is fine.....what a relief! I am sick of scams out there! Stealing!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The word 'awesome' is a strong positive indicator, suggesting that the user had an excellent experience or found something impressive.",
+        "sentiment": "positive",
+        "tweet": "http://twurl.nl/epkr4b - awesome come back from @biz (via @fredwilson)",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user mentions being in Montreal for a long weekend, which is typically associated with relaxation and enjoyment (as indicated by 'R&R'). The phrase 'Much needed' suggests that the person feels this break is important or necessary, indicating satisfaction or relief. Overall, these elements convey a positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "In montreal for a long weekend of R&amp;R. Much needed.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses enthusiasm about Booz Allen Hamilton's internal tool, using words like 'bad ass' and 'way cool', which are positive expressions of excitement.",
+        "sentiment": "positive",
+        "tweet": "Booz Allen Hamilton has a bad ass homegrown social collaboration platform. Way cool!  #ttiv",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet is announcing a customer innovation award winner, which is generally positive news as it recognizes achievement and success.",
+        "sentiment": "positive",
+        "tweet": "[#MLUC09] Customer Innovation Award Winner: Booz Allen Hamilton -- http://ping.fm/c2hPP",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses a preference for one product over another while acknowledging a past choice that turned out to be a mistake. The user mentions loving their current camera but not as much as another model, indicating some dissatisfaction with their purchase decision.",
+        "sentiment": "negative",
+        "tweet": "@SoChi2 I current use the Nikon D90 and love it, but not as much as the Canon 40D/50D. I chose the D90 for the  video feature. My mistake.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses satisfaction with Google as a reliable source and\u6000\u5ff5\u4e0e\u7236\u4eb2\u4e00\u8d77\u5de5\u4f5c\u7684\u7ecf\u5386\uff0c\u6574\u4f53\u60c5\u611f\u662f\u6b63\u9762\u7684\u3002",
+        "sentiment": "positive",
+        "tweet": "@phyreman9 Google is always a good place to look. Should've mentioned I worked on the Mustang w/ my Dad, @KimbleT.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expresses a dislike for the Android Google Phone's sliding screen, fearing they might break it easily. They explicitly state their preference for the iPhone.",
+        "sentiment": "negative",
+        "tweet": "Played with an android google phone. The slide out screen scares me I would break that fucker so fast. Still prefer my iPhone.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a critical view of resuming military tribunals, suggesting that powerful individuals like AIG executives and Chrysler debt holders are being targeted. This implies dissatisfaction with the government's actions.",
+        "sentiment": "negative",
+        "tweet": "US planning to resume the military tribunals at Guantanamo Bay... only this time those on trial will be AIG execs and Chrysler debt holders",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user expresses feelings of boredom and discomfort from their tattoos being itchy, but ends with an emoji indicating they might be joking or not too serious about the situation. The use of 'aha =)' suggests a light-hearted tone despite the negative words.",
+        "sentiment": "negative",
+        "tweet": "omg so bored &amp; my tattoooos are so itchy!!  help! aha =)",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user expresses feeling 'itchy and miserable', which are strong indicators of discomfort and unhappiness.",
+        "sentiment": "negative",
+        "tweet": "I'm itchy and miserable!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user mentions they are 'not itchy', which indicates a neutral state regarding their current condition. The use of 'lol' suggests light-heartedness or humor in the response, but there isn't strong positive or negative language present.",
+        "sentiment": "negative",
+        "tweet": "@sekseemess no. I'm not itchy for now. Maybe later, lol.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a positive feeling about enjoying educational content and reminiscing about school, which indicates a positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "RT @jessverr I love the nerdy Stanford human biology videos - makes me miss school. http://bit.ly/13t7NR",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet mentions that using LyX has had a steep learning curve and some craziness, which could indicate initial difficulties or challenges. However, the user ultimately states that LyX is 'really good' for long documents and even calls it 'insane' for shorter ones. The positive adjectives like 'good' and 'insane' (in a complimentary context) suggest an overall positive sentiment despite the initial hurdles.",
+        "sentiment": "positive",
+        "tweet": "@spinuzzi: Has been a bit crazy, with steep learning curve, but LyX is really good for long docs. For anything shorter, it would be insane.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses strong positive feelings towards the artist and his song through multiple heart emojis and affectionate language.",
+        "sentiment": "positive",
+        "tweet": "I'm listening to \"P.Y.T\" by Danny Gokey &lt;3 &lt;3 &lt;3 Aww, he's so amazing. I &lt;3 him so much :)",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet mentions 'going to sleep', which could indicate tiredness, but it's followed by 'on a bike ride', suggesting an enjoyable activity. The use of a smiley face emoticon ':]' adds positivity.",
+        "sentiment": "positive",
+        "tweet": "is going to sleep then on a bike ride:]",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user mentions being unable to sleep due to a toothache, which indicates discomfort and distress.",
+        "sentiment": "negative",
+        "tweet": "cant sleep... my tooth is aching.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a lack of enthusiasm about having no plans for the day and mentions going back to sleep, which indicates dissatisfaction or boredom.",
+        "sentiment": "negative",
+        "tweet": "Blah, blah, blah same old same old. No plans today, going back to sleep I guess.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user expresses relief at not participating in an event due to extremely high temperatures, indicating a negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "glad i didnt do Bay to Breakers today, it's 1000 freaking degrees in San Francisco wtf",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses frustration towards the Obama administration for allowing bonuses to individuals involved in a Ponzi scheme at AIG, which is generally viewed negatively due to the unethical nature of such schemes and the public backlash against financial misconduct.",
+        "sentiment": "negative",
+        "tweet": "?Obama Administration Must Stop Bonuses to AIG Ponzi Schemers ... http://bit.ly/2CUIg",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses concern about Citigroup's financial stability, comparing them to AIG which faced significant issues. The use of strong language like 'deep s&^t' indicates a negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "started to think that Citi is in really deep s&amp;^t. Are they gonna survive the turmoil or are they gonna be the next AIG?",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet contains a typo ('hate'n') which might be intended as 'hatin'' meaning hating something, but it's unclear what exactly is being hated. The mention of 'AiG' could refer to various things like American Idol Gives Back or another entity. Without clear context, determining the sentiment is difficult.",
+        "sentiment": "negative",
+        "tweet": "ShaunWoo hate'n on AiG",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user used strong positive language like 'AWESOME', which indicates a very favorable opinion about seeing Star Trek.",
+        "sentiment": "positive",
+        "tweet": "@YarnThing you will not regret going to see Star Trek. It was AWESOME!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses frustration about a trend where Michael Lewis and Malcolm Gladwell are being overly criticized, indicating dissatisfaction with this phenomenon.",
+        "sentiment": "negative",
+        "tweet": "annoying new trend on the internets:  people picking apart michael lewis and malcolm gladwell.  nobody wants to read that.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet uses 'highly recommend', which is a strong positive endorsement of something.",
+        "sentiment": "positive",
+        "tweet": "Highly recommend: http://tinyurl.com/HowDavidBeatsGoliath by Malcolm Gladwell",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expresses enthusiasm for two books by Malcolm Gladwell, 'Blink' and 'The Tipping Point', using the word 'amazing'. This indicates a positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "Blink by malcolm gladwell amazing book and The tipping point!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The phrase 'man crush' typically refers to a strong infatuation or admiration for someone, often implying a romantic interest but not always. In this context, it seems the user is expressing a positive sentiment towards Malcolm Gladwell by stating he could become their new man crush.",
+        "sentiment": "positive",
+        "tweet": "Malcolm Gladwell might be my new man crush",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expresses frustration about commercials during ESPN programming, indicating a negative experience.",
+        "sentiment": "negative",
+        "tweet": "omg. The commercials alone on ESPN are going to drive me nuts.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses interest in playing with the Twitter API, which is positive. The mention of needing to take a class or find a friend suggests curiosity and openness towards learning, further indicating positivity.",
+        "sentiment": "positive",
+        "tweet": "@robmalon Playing with Twitter API sounds fun.  May need to take a class or find a new friend who like to generate results with API code.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet contains a friendly greeting 'Hello Twitter API ;)', which uses a smiley emoji indicating positivity.",
+        "sentiment": "positive",
+        "tweet": "Hello Twitter API ;)",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user mentions that Twitter's API is slow and clients are not good, which indicates dissatisfaction with both aspects.",
+        "sentiment": "negative",
+        "tweet": "@morind45 Because the twitter api is slow and most client's aren't good.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The phrase 'can be a butt sometimes' suggests that Yahoo Answers occasionally behaves in an annoying or frustrating manner, which indicates dissatisfaction.",
+        "sentiment": "negative",
+        "tweet": "yahoo answers can be a butt sometimes",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet mentions 'scrapbooking', which is a creative activity often associated with enjoyment and relaxation. The use of '=D' indicates happiness, as it's an emoticon showing a smiley face.",
+        "sentiment": "positive",
+        "tweet": "is scrapbooking with Nic =D",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet is a retweet sharing an article about Wolfram Alpha's capabilities compared to Google. The title suggests that Wolfram Alpha does certain things better, which could be seen as positive for Wolfram Alpha but neutral or negative towards Google depending on context. However, since the focus is on what Wolfram Alpha does better and it's presented in a factual manner without explicit sentiment words like 'great' or 'terrible', the overall sentiment leans more towards neutral.",
+        "sentiment": "positive",
+        "tweet": "RT @mashable: Five Things Wolfram Alpha Does Better (And Vastly Different) Than Google - http://bit.ly/6nSnR",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expresses excitement about changing their profile picture to something related to basketball, indicating a positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "just changed my default pic to a Nike basketball cause bball is awesome!!!!!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet mentions 'Nike layoffs started today', which is a negative event, and uses an emoji ':-( ' indicating sadness or disappointment.",
+        "sentiment": "negative",
+        "tweet": "RT @SmartChickPDX: Was just told that Nike layoffs started today :-(",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a positive memory associated with working at Nike, using an exclamation mark and smiley face to convey enthusiasm.",
+        "sentiment": "positive",
+        "tweet": "Back when I worked for Nike we had one fav word : JUST DO IT! :)",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user mentions being 'totally inspired', which indicates a positive emotion towards the Nike commercial.",
+        "sentiment": "positive",
+        "tweet": "By the way, I'm totally inspired by this freaky Nike commercial: http://snurl.com/icgj9",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The use of 'supposed to' indicates expectation, but it's followed by a smiley face ':)', which conveys positivity.",
+        "sentiment": "positive",
+        "tweet": "Class... The 50d is supposed to come today :)",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses a need for help regarding lambda calculus, which indicates frustration or confusion on the part of the user.",
+        "sentiment": "negative",
+        "tweet": "needs someone to explain lambda calculus to him! :(",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user mentions taking a difficult exam, which is generally stressful but also shows dedication.",
+        "sentiment": "positive",
+        "tweet": "Took the Graduate Field Exam for Computer Science today.  Nothing makes you feel like more of an idiot than lambda calculus.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet contains words like 'THANKS', which indicates gratitude, and mentions of people or groups in a positive light. The overall tone is enthusiastic with the use of uppercase letters and multiple exclamation points.",
+        "sentiment": "positive",
+        "tweet": "SHOUT OUTS TO ALL EAST PALO ALTO FOR BEING IN THE BUILDIN KARIZMAKAZE 50CAL GTA! ALSO THANKS TO PROFITS OF DOOM UNIVERSAL HEMPZ CRACKA......",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses a reluctance to live in East Palo Alto and implies that staying there is temporary or less desirable.",
+        "sentiment": "negative",
+        "tweet": "@legalgeekery Yeahhhhhhhhh, I wouldn't really have lived in East Palo Alto if I could have avoided it.  I guess it's only for the summer.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses gratitude towards @accannis and @edog1203, mentioning that their Stanford course is great, really helpful, and informative. These are all positive sentiments.",
+        "sentiment": "positive",
+        "tweet": "@accannis @edog1203 Great Stanford course. Thanks for making it available to the public! Really helpful and informative for starting off!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user mentions working until 6 pm but then expresses excitement about going to watch the Lakers, indicating a positive outlook despite their busy schedule.",
+        "sentiment": "positive",
+        "tweet": "@ work til 6pm... lets go lakers!!!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The use of 'Damn you' indicates frustration or anger towards North Korea, which conveys a negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "Damn you North Korea. http://bit.ly/KtMeQ",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a desire to take extreme military action against North Korea, which indicates strong negative feelings towards that country.",
+        "sentiment": "negative",
+        "tweet": "Can we just go ahead and blow North Korea off the map already?",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet uses strong language such as 'douchebaggery,' which is derogatory and conveys frustration or anger towards North Korea. Additionally, the statement that 'China doesn't even like you anymore' suggests disapproval of North Korea's actions from another country, further indicating a negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "North Korea, please cease this douchebaggery. China doesn't even like you anymore. http://bit.ly/NeHSl",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses frustration about Nancy Pelosi's visit to China, questioning both her presence there and who is funding it. The use of strong language like 'hell' and 'freakin' indicates anger or irritation.",
+        "sentiment": "negative",
+        "tweet": "Why the hell is Pelosi in freakin China? and on whose dime?",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses concern about excessive spending, comparing it to major companies like Chrysler and GM. It uses strong language like 'burning more cash' and refers to stopping a 'financial tsunami,' indicating worry or frustration. The mention of 'bailout' as taking a handout suggests criticism towards financial assistance measures.",
+        "sentiment": "negative",
+        "tweet": "Are YOU burning more cash $$$ than Chrysler and GM? Stop the financial tsunami. Where \"bailout\" means taking a handout!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user expressed frustration about insects harming their spinach plant, which indicates a negative emotion.",
+        "sentiment": "negative",
+        "tweet": "insects have infected my spinach plant :(",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses frustration with mosquitoes, using strong language like 'burn em slowly', 'bitin the shit outta me', and calling them 'assholes'. These expressions indicate a negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "wish i could catch every mosquito in the world n burn em slowly.they been bitin the shit outta me 2day.mosquitos are the assholes of insects",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user mentions hating insects after going to church. The word 'hate' indicates a strong dislike, which conveys a negative emotion.",
+        "sentiment": "negative",
+        "tweet": "just got back from church, and I totally hate insects.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses dissatisfaction with McDonald's food, specifically the eggs causing sickness, which indicates a negative sentiment. However, there is also excitement about the Lakers team ('Laker up', 'go lakers'), showing positive feelings towards sports. The overall sentiment leans more negative due to the stronger expression of discomfort and frustration regarding the meal.",
+        "sentiment": "negative",
+        "tweet": "Just got mcdonalds goddam those eggs make me sick. O yeah Laker up date go lakers. Not much of an update? Well it's true so suck it",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user expresses a strong desire for McDonald's, using 'ohhdee' which is an intensifier showing excitement or eagerness. The use of 'lol =]' at the end suggests they are in a good mood and perhaps sharing this feeling humorously with others.",
+        "sentiment": "positive",
+        "tweet": "omgg i ohhdee want mcdonalds damn i wonder if its open lol =]",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expressed frustration about their history exam by using 'ugh', indicating a negative emotion.",
+        "sentiment": "negative",
+        "tweet": "History exam studying ugh",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user expresses dislike towards revision by saying 'hate', finds it 'boring', and feels unprepared with an emoji indicating sadness. These elements convey a negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "I hate revision, it's so boring! I am totally unprepared for my exam tomorrow :( Things are not looking good...",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user mentions having a higher physics exam tomorrow but expresses reluctance by saying 'not looking forward to it much.' The use of ':(' further indicates sadness or dissatisfaction. These elements suggest a negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "Higher physics exam tommorow, not lookin forward to it much :(",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses frustration about being out of work during exam season despite it being a bank holiday. The use of 'sucks:' indicates dissatisfaction.",
+        "sentiment": "negative",
+        "tweet": "It's a bank holiday, yet I'm only out of work now. Exam season sucks:(",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet mentions 'culprits', which has a negative connotation, suggesting blame or fault on Cheney and Bush.",
+        "sentiment": "negative",
+        "tweet": "Cheney and Bush are the real culprits - http://fwix.com/article/939496",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses frustration with both life and Dick Cheney, indicating a negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "Life?s a bitch? and so is Dick Cheney. #p2 #bipart #tlot #tcot #hhrs #GOP #DNC http://is.gd/DjyQ",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet refers to Dick Cheney's speech as 'dishonest', which is a negative term indicating disapproval or criticism of the content.",
+        "sentiment": "negative",
+        "tweet": "Dick Cheney's dishonest speech about torture, terror, and Obama. -Fred Kaplan Slate. http://is.gd/DiHg",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet uses strong language such as 'anti-aborion zealots' and compares them unfavorably by saying they can't even attract flies to a dump. This indicates a negative sentiment towards the Republican party.",
+        "sentiment": "negative",
+        "tweet": "\"The Republican party is a bunch of anti-abortion zealots who couldn't draw flies to a dump.\" -- Neal Boortz (just now, on the radio)",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user is questioning whether Twitter's Connections API is broken because some of their tweets did not appear on Twitter. This indicates frustration or concern about the functionality of the service, which suggests a negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "is Twitter's connections API broken? Some tweets didn't make it to Twitter...",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user expresses frustration with Twitter's API timeout issue using strong language like 'hate', multiple exclamation marks, and an emoji indicating sadness.",
+        "sentiment": "negative",
+        "tweet": "i srsly hate the stupid twitter API timeout thing, soooo annoying!!!!! :(",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses satisfaction with @kswedberg's 'Learning jQuery' book and recommends another resource, indicating positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "@psychemedia I really liked @kswedberg's \"Learning jQuery\" book. http://bit.ly/pg0lT is worth a look too",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet mentions 'Very Interesting Ad', which indicates a positive sentiment towards the advertisement.",
+        "sentiment": "positive",
+        "tweet": "Very Interesting Ad from Adobe by Goodby, Silverstein &amp; Partners - YouTube - Adobe CS4: Le Sens Propre http://bit.ly/VprpT",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses excitement about a new website launch by Goodby Silverstein Agency, using words like 'Great!', which indicates a positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "Goodby Silverstein agency new site! http://www.goodbysilverstein.com/ Great!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses enjoyment of a website and appreciation for the finder, indicating positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "RT @designplay Goodby, Silverstein's new site: http://www.goodbysilverstein.com/ I enjoy it. *nice find!*",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses excitement about a collaboration between two companies, mentioning 'ever amazing' which is positive language. The user also mentions looking forward to using After Effects, indicating enthusiasm.",
+        "sentiment": "positive",
+        "tweet": "The ever amazing Psyop and Goodby Silverstein &amp; Partners for HP! http://bit.ly/g2rU8 Have to go play with After Effects now!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses positive sentiment by mentioning 'Love the nike #mostvaluablepuppets campaign', indicating appreciation for the campaign.",
+        "sentiment": "positive",
+        "tweet": "top ten most watched on Viral-Video Chart.  Love the nike #mostvaluablepuppets campaign from Wieden &amp; Kennedy http://bit.ly/nR1n9",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expresses excitement about receiving a G2, which indicates a positive emotion.",
+        "sentiment": "positive",
+        "tweet": "zomg!!! I have a G2!!!!!!!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses excitement about receiving a free G2, which is likely a desirable item or service. The use of 'Free' and the exclamation mark indicate positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "Ok so lots of buzz from IO2009 but how lucky are they - a Free G2!! http://is.gd/Hyzl",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expresses excitement about receiving a free G2 Android phone at Google I/O, which indicates a positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "just got a free G2 android at google i/o!!!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user mentions 'retiring' their old device, which could imply dissatisfaction with it. However, they are excited about the new G2 ('woot'), indicating a positive sentiment overall.",
+        "sentiment": "positive",
+        "tweet": "Guess I'll be retiring my G1 and start using my developer G2 woot #googleio",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses happiness for someone named Philip attending Google IO, which indicates a positive emotion.",
+        "sentiment": "positive",
+        "tweet": "I am happy for Philip being at GoogleIO today",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expressed excitement about an upcoming game, indicating a positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "Lakers played great!  Cannot wait for Thursday night Lakers vs. ???",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet mentions 'viral marketing at its best,' which indicates a positive sentiment towards the strategy used by Judd Apatow.",
+        "sentiment": "positive",
+        "tweet": "Judd Apatow creates fake sitcom on NBC.com to market his new movie... viral marketing at its best. http://is.gd/K0yK",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses frustration and anger towards the Acia Pills brand, mentioning that they are spamming with messages which is causing annoyance to the user.",
+        "sentiment": "negative",
+        "tweet": "VIRAL MARKETING FAIL. This Acia Pills brand oughta get shut down for hacking into people's messenger's.  i get 5-6 msgs in a day! Arrrgh!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user expressed enjoyment by laughing out loud (LOL) while watching 'Night at the Museum', indicating a positive experience.",
+        "sentiment": "positive",
+        "tweet": "watching Night at The Museum . Lmao",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expressed strong positive feelings by using 'loved' and an exclamation mark, indicating a very favorable opinion about the movie.",
+        "sentiment": "positive",
+        "tweet": "i loved night at the museum!!!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user mentions that they 'went to see the new Night at the Museum with Rachel.' This indicates a positive experience as they chose to spend time together watching a movie, which is generally an enjoyable activity. Additionally, the tweet ends with 'it was good,' explicitly stating their satisfaction with the film.",
+        "sentiment": "positive",
+        "tweet": "just got back from the movies.  went to see the new night at the museum with rachel.  it was good",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses a desire to go on a date, which is generally associated with positive feelings and excitement. The use of 'soooooo good' emphasizes enthusiasm about the movie.",
+        "sentiment": "positive",
+        "tweet": "@shannyoday I will take you on a date to see night at the museum 2 whenever you want...it looks soooooo good",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user mentions 'Getting Really Good', which indicates a positive experience.",
+        "sentiment": "positive",
+        "tweet": "no watching The Night At The Museum. Getting Really Good",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet mentions 'perfect Monday', which indicates a positive feeling about the day.",
+        "sentiment": "positive",
+        "tweet": "Night at the Museum, Wolverine and junk food - perfect monday!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses a positive experience with 'Night at the Museum 2', mentioning that it's a 'pretty crazy movie' and praising the cast, especially Robin Williams.",
+        "sentiment": "positive",
+        "tweet": "saw night at the museum 2 last night.. pretty crazy movie.. but the cast was awesome so it was well worth it. Robin Williams forever!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses disappointment about not watching 'UP' but decides to watch 'Night at the Museum' instead, ending with a light-hearted joke.",
+        "sentiment": "negative",
+        "tweet": "Night at the Museum tonite instead of UP. :( oh well. that 4 yr old better enjoy it. LOL",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses dissatisfaction towards government actions, specifically mentioning 'unfortunate' and implying negative consequences for the American people. The use of words like 'back of' suggests burden or exploitation, contributing to a negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "It's unfortunate that after the Stimulus plan was put in place twice to help GM on the back of the American people has led to the inevitable",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user is expressing frustration about government funding allocation, questioning why money is being given to GM instead of supporting unemployment programs. The tone suggests dissatisfaction and a critical view towards current policies.",
+        "sentiment": "negative",
+        "tweet": "Tell me again why we are giving more $$ to GM?? We should use that $ for all the programs that support the unemployed.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet uses words like 'dies', which could imply a negative event, but also includes laughter ('boo hahaha'), suggesting the user is not genuinely upset. The overall tone seems to mix humor with potential sarcasm or irony.",
+        "sentiment": "negative",
+        "tweet": "@jdreiss oh yes but if GM dies it will only be worth more boo hahaha",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user expressed frustration about Time Warner Cable going down multiple times, which indicates a negative experience.",
+        "sentiment": "negative",
+        "tweet": "Time Warner cable is down again 3rd time since Memorial Day bummer!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user expresses dissatisfaction with being overcharged by Time Warner for a slow internet connection. They prefer paying reasonable taxes for faster service instead.",
+        "sentiment": "negative",
+        "tweet": "I would rather pay reasonable yearly taxes for \"free\" fast internet, than get gouged by Time Warner for a slow connection.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user is expressing frustration because their DVR stopped working while they were watching a live event, specifically an Electronic Arts (EA) press conference. They are upset about losing access to the content they wanted to watch and directed their anger towards Time Warner, likely referring to their cable or internet service provider. The use of 'NOOOOOO' indicates strong negative emotion, and the word 'Hate you' clearly conveys dislike towards Time Warner.",
+        "sentiment": "negative",
+        "tweet": "NOOOOOOO my DVR just died and I was only half way through the EA presser. Hate you Time Warner",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet contains multiple expletives and strong language directed at Time Warner Cable, indicating frustration with their service. The user expresses dissatisfaction about poor HD channel reception despite having a high-end TV.",
+        "sentiment": "negative",
+        "tweet": "F*ck Time Warner Cable!!! You f*cking suck balls!!! I have a $700 HD tv &amp; my damn HD channels hardly ever come in. Bullshit!!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user expresses strong dissatisfaction with Time Warner's customer service, using words like 'worse' and stating they'll never use them again.",
+        "sentiment": "negative",
+        "tweet": "time warner has the worse customer service ever. I will never use them again",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user expresses frustration towards Time Warner by calling them 'the devil,' which indicates a strong dislike. Additionally, they mention that it's the worst possible time for the internet to go out, showing dissatisfaction and inconvenience caused by the situation.",
+        "sentiment": "negative",
+        "tweet": "Time warner is the devil. Worst possible time for the Internet to go out.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user expressed frustration towards Time Warner for lack of internet service.",
+        "sentiment": "negative",
+        "tweet": "Fuck no internet damn time warner!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses frustration with Time Warner's service timing, making it difficult for the user to access MTV.com and watch 'The Hills'. The use of multiple exclamation marks ('wtfffff') indicates strong negative emotions.",
+        "sentiment": "negative",
+        "tweet": "time warner really picks the worst time to not work. all i want to do is get to mtv.com so i can watch the hills. wtfffff.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses frustration with Time Warner, mentions wishing for a different service (Vios), and complains about buffering issues while trying to watch the Mets game. The use of strong language ('hate', 'fricken') indicates negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "I hate Time Warner! Soooo wish I had Vios. Cant watch the fricken Mets game w/o buffering. I feel like im watching free internet porn.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses relief at getting rid of Time Warner, which is positive, and mentions enjoying a nap with roommates cooking, indicating relaxation and satisfaction. The use of smiley face also conveys happiness.",
+        "sentiment": "positive",
+        "tweet": "Ahh...got rid of stupid time warner today &amp; now taking a nap while the roomies cook for me. Pretty good end for a monday :)",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The word 'crap' indicates a strong negative opinion about Time Warner's HD lineup.",
+        "sentiment": "negative",
+        "tweet": "Time Warner's HD line up is crap.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses frustration towards Time Warner Cable, mentions a modem exploding which is a negative experience, and criticizes Susan Boyle negatively.",
+        "sentiment": "negative",
+        "tweet": "is being fucked by time warner cable. didnt know modems could explode. and Susan Boyle sucks too!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet mentions Time Warner Cable's slogan, which is 'Where calling it a day at 2pm Happens.' This suggests that their service allows customers to end their workday early or enjoy more leisure time. The implication is positive as it highlights convenience and possibly good customer service.",
+        "sentiment": "positive",
+        "tweet": "Time Warner Cable slogan: Where calling it a day at 2pm Happens.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user mentions recovering from surgery, which is a serious situation but not inherently negative. However, they express a desire for someone to be present with them using the sad emoji ':('. This indicates loneliness or unhappiness during their recovery.",
+        "sentiment": "negative",
+        "tweet": "Recovering from surgery..wishing @julesrenner was here :(",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses discomfort and dislike towards medical settings, indicating a negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "My wrist still hurts. I have to get it looked at. I HATE the dr/dentist/scary places. :( Time to watch Eagle eye. If you want to join, txt!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses frustration and pain. The user mentions that the dentist lied about not feeling discomfort, which indicates disappointment. They also express confusion or anger about how many pills they can take, suggesting distress.",
+        "sentiment": "negative",
+        "tweet": "THE DENTIST LIED! \" U WON'T FEEL ANY DISCOMORT! PROB WON'T EVEN NEED PAIN PILLS\" MAN U TWIPPIN THIS SHIT HURT!! HOW MANY PILLS CAN I TAKE!!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user mentions that their dentist is 'great', which indicates a positive aspect of their experience. However, they also note that the dentist is 'expensive', which introduces a negative element due to cost concerns. The overall sentiment leans towards neutral because while there's appreciation for the service quality, the high expense causes dissatisfaction.",
+        "sentiment": "negative",
+        "tweet": "@kirstiealley my dentist is great but she's expensive...=(",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user mentions studying for a math exam and having a dentist appointment, both of which are stress-inducing events. However, they use smiley faces ( ;) ), indicating that despite the challenges, they're maintaining a positive outlook.",
+        "sentiment": "positive",
+        "tweet": "is studing math ;) tomorrow exam and dentist :)",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The use of 'wrong' twice emphasizes dissatisfaction.",
+        "sentiment": "negative",
+        "tweet": "my dentist was wrong... WRONG",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user mentions going to the dentist but uses a neutral emoji ':|', which doesn't clearly indicate positivity or negativity.",
+        "sentiment": "negative",
+        "tweet": "Going to the dentist later.:|",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses frustration about having to look for cars, comparing it unfavorably to going to the dentist, which is generally disliked. The user also asks if anyone has a good car at a fair price, indicating they are looking but not finding satisfaction yet. Overall, the sentiment is negative because of the expressed dislike and frustration.",
+        "sentiment": "negative",
+        "tweet": "Son has me looking at cars online.  I hate car shopping.  Would rather go to the dentist!  Anyone with a good car at a good price to sell?",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet describes an uncomfortable situation where Luke and I were stopped after leaving Safeway, forced to empty their pockets and lift their shirts. The use of 'how jacked up' indicates frustration or anger about the incident.",
+        "sentiment": "negative",
+        "tweet": "luke and i got stopped walking out of safeway and asked to empty our pockets and lift our shirts. how jacked up is that?",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The phrase 'rock n roll' typically has a positive connotation associated with excitement, energy, and enjoyment. The use of 'very' intensifies this positive feeling.",
+        "sentiment": "positive",
+        "tweet": "Safeway is very rock n roll tonight",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet mentions that a Safeway bathroom still has an unpleasant odor ('smells like ass'), which indicates dissatisfaction with the cleanliness of the facilities.",
+        "sentiment": "negative",
+        "tweet": "The safeway bathroom still smells like ass!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The phrase 'they move like they're dead' suggests that employees at Safeway are moving very slowly or not efficiently, which implies dissatisfaction with their service.",
+        "sentiment": "negative",
+        "tweet": "At safeway on elkhorn, they move like they're dead!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user expresses a preference for seeing Dwight Howard with Nike instead of Adidas, indicating dissatisfaction with his current brand association.",
+        "sentiment": "negative",
+        "tweet": "i love Dwight Howard's vitamin water commercial... now i wish he was with NIKE and not adidas. lol.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expressed dissatisfaction by saying they found nothing at Nike Factory, which indicates a negative experience there. However, the mention of going to another store (Banana Republic Outlet) might suggest some level of optimism or continuation in their shopping trip, but overall, the primary sentiment is negative due to the initial disappointment.",
+        "sentiment": "negative",
+        "tweet": "Found NOTHING at Nike Factory :/ Off to Banana Republic Outlet! http://myloc.me/2zic",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user mentions 'lovin his Nike', which indicates a positive feeling towards the product. Additionally, he's using them for running on the spot in his bedroom, suggesting satisfaction with their performance even in such conditions.",
+        "sentiment": "positive",
+        "tweet": "is lovin his Nike  already and that's only from running on the spot in his bedroom",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user mentions successfully implementing a feature (bio collapsing) using jQuery, which indicates satisfaction with their accomplishment. The use of 'Yay' and the mention of slide animations suggest excitement about the result.",
+        "sentiment": "positive",
+        "tweet": "@matthewcyan I finally got around to using jquery to make my bio collapse. Yay for slide animations.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet uses words like 'right', 'LOL', 'get there', and mentions having high expectations similar to Warren Buffett's approach. These indicate a positive outlook.",
+        "sentiment": "positive",
+        "tweet": "@PDubyaD right!!! LOL we'll get there!! I have high expectations, Warren Buffet style.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet is sharing a quote from Warren Buffett about planting trees and reaping benefits later. This reflects on patience, growth, and positive outcomes over time.",
+        "sentiment": "positive",
+        "tweet": "RT @blknprecious1: RT GREAT @dbroos \"Someone's sitting in the shade today because someone planted a tree a long time ago.\"- Warren Buffet",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet discusses Warren Buffett's success through investment rather than work, highlighting his achievement as becoming temporarily the richest man. This is presented neutrally without explicit positive or negative language.",
+        "sentiment": "positive",
+        "tweet": "Warren Buffet became (for a time) the richest man in the United States, not by working but investing in 1 Big idea which lead to the fortune",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses excitement about Notre Dame having seven highly-rated receivers in the NCAA rankings. The use of smiley faces and words like 'sweet' indicate a positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "According to the create a school, Notre Dame will have 7 receivers in NCAA 10 at 84 or higher rating :) *sweet*",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet mentions that Amazon's Kindle support was 'great', which indicates a positive sentiment. The user also states their experience with Amazon support as being good, further supporting a positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "@BlondeBroad it's definitely under warranty &amp; my experience is the amazon support for kindle is great! had to contact them about my kindle2",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expresses frustration with Time Warner's customer service, indicating a negative experience.",
+        "sentiment": "negative",
+        "tweet": "Time Warner Road Runner customer support here absolutely blows. I hate not having other high-speed net options. I'm ready to go nuclear.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses frustration with Time Warner Cable representatives, using strong language like 'dumber than nails', and exclamation marks. The user is upset because the cable stopped working after being functional just minutes before.",
+        "sentiment": "negative",
+        "tweet": "Time Warner cable phone reps r dumber than nails!!!!! UGH! Cable was working 10 mins ago now its not WTF!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet mentions that they 'tried' which could indicate some effort, but it's followed by a negative experience with Time Warner not being nice. However, the smiley face at the end suggests a positive sentiment despite the initial frustration.",
+        "sentiment": "positive",
+        "tweet": "@siratomofbones we tried but Time Warner wasn't being nice so we recorded today. :)",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses frustration with Time Warner's service, mentioning that the installation was messed up and they have to wait another week without internet. The use of strong language like 'f'ed up', 'FML', and multiple exclamation marks indicate a negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "OMG - time warner f'ed up my internet install - instead of today  its now NEXT saturday - another week w/o internet! &amp;$*ehfa^V9fhg[*# fml.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user expresses frustration about encountering an unusually long line at Time Warner, using strong language like 'wth' and 'ugh', which indicates negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "wth..i have never seen a line this loooong at time warner before, ugh.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user is expressing impatience about waiting for someone, which indicates a negative emotion.",
+        "sentiment": "negative",
+        "tweet": "Impatiently awaiting the arrival of the time warner guy. It's way too pretty to be inside all afternoon",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet mentions 'Really Frustrating...', which indicates a strong negative emotion.",
+        "sentiment": "negative",
+        "tweet": "Naive Bayes using EM for Text Classification. Really Frustrating...",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses excitement about visiting Stanford University, wanting to return to college, and planning for their children's future education there. These are positive sentiments.",
+        "sentiment": "positive",
+        "tweet": "We went to Stanford University today. Got a tour. Made me want to go back to college. It's also decided all of our kids will go there.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses frustration with unwanted calls related to car warranties and mentions the ineffectiveness of changing phone numbers as a solution. The use of '#d-bags', which is slang for 'dead bags' or something worthless, indicates contempt towards the callers. Overall, the sentiment is negative.",
+        "sentiment": "negative",
+        "tweet": "@KarrisFoxy If you're being harassed by calls about your car warranty, changing your number won't fix that. They call every number. #d-bags",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user expresses frustration by mentioning being annoyed at receiving too many calls from United Blood Services, comparing them to car warranty companies which are often associated with unwanted telemarketing calls. The use of the word 'blocked' indicates that they took action against these communications, showing dissatisfaction.",
+        "sentiment": "negative",
+        "tweet": "Just blocked United Blood Services using Google Voice. They call more than those Car Warranty guys.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses dissatisfaction towards AT&T by calling it a 'complete fail', which indicates a strong negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "#at&amp;t is complete fail.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet uses strong language like 'OH SNAP', which can indicate surprise or shock, but without additional context it's hard to determine if the sentiment is positive or negative. The mention of working at AT&T could be neutral.",
+        "sentiment": "negative",
+        "tweet": "@broskiii OH SNAP YOU WORK AT AT&amp;T DON'T YOU",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user expresses dissatisfaction with their experience regarding AT&T's phone service, specifically mentioning that the company 'sucks when it comes to having a signal.' This indicates frustration and negative sentiment towards the service provider.",
+        "sentiment": "negative",
+        "tweet": "@Mbjthegreat i really dont want AT&amp;T phone service..they suck when it comes to having a signal",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses frustration with AT&T's approach by using a strong and offensive phrase 'F__k you, give us your money.' This indicates dissatisfaction and anger towards the company.",
+        "sentiment": "negative",
+        "tweet": "I say we just cut out the small talk: AT&amp;T's new slogan: F__k you, give us your money. (Apologies to Bob Geldof.)",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses frustration with AT&T's pricing, specifically mentioning being 'pissed about' the higher cost of an iPhone upgrade mid-contract. The user feels they are being overcharged by $200 and is unwilling to pay $499 when expecting a lower price of $299. This clearly conveys dissatisfaction and anger towards AT&T's pricing strategy.",
+        "sentiment": "negative",
+        "tweet": "pissed about at&amp;t's mid-contract upgrade price for the iPhone (it's $200 more) I'm not going to pay $499 for something I thought was $299",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user mentions that Safari 4 is 'fast', which indicates a positive experience with the product. The smiley face ':)' further reinforces this positive sentiment. Although they refer to their internet connection as 'shitty' and mention using AT&T tethering, these aspects are about external factors (network provider) rather than the performance of Safari itself. Therefore, focusing on the main subject of the tweet, which is Safari 4's speed, leads to a positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "Safari 4 is fast :) Even on my shitty AT&amp;T tethering.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet contains a profanity ('fucking') which indicates frustration or anger towards AT&T, suggesting a negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "@ims What is AT&amp;T fucking up?",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses frustration towards AT&T for not supporting their services adequately with the new iPhone 3.0 update, using strong negative language like 'dropped the ball', 'crap', and '#att SUCKS!!!'. These words clearly indicate dissatisfaction and anger.",
+        "sentiment": "negative",
+        "tweet": "@springsingfiend @dvyers @sethdaggett @jlshack AT&amp;T dropped the ball and isn't supporting crap with the new iPhone 3.0... FAIL #att SUCKS!!!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user expressed happiness about getting a phone but frustration towards AT&T.",
+        "sentiment": "positive",
+        "tweet": "@MMBarnhill yay, glad you got the phone! Still, damn you, AT&amp;T.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user expresses dissatisfaction by stating they will continue using Google instead of Bing, indicating a negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "Talk is Cheap: Bing that, I?ll stick with Google. http://bit.ly/XC3C8",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses frustration with Twitter's inability to fully remove deleted tweets from search results on Summize. The user is clearly upset about this issue and is urging Twitter to fix it.",
+        "sentiment": "negative",
+        "tweet": "@defsounds WTF is the point of deleting tweets if they can still be found in summize and searches? Twitter, please fix that. Thanks and bye",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet contains words like 'love', which is a strong positive indicator, and an emoji ':D' that conveys happiness or excitement. The overall tone of the message is friendly and upbeat.",
+        "sentiment": "positive",
+        "tweet": "@ArunBasilLal I love Google Translator too ! :D Good day mate !",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expressed excitement about their new purchase by using an exclamation mark.",
+        "sentiment": "positive",
+        "tweet": "reading on my new Kindle2!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expresses excitement about receiving their Kindle2 by using words like 'LOVE' and an emoji ':)', which are strong indicators of positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "My Kindle2 came and I LOVE it! :)",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses strong positive feelings about a new Kindle device, giving it a name and mentioning how useful the 'cookbook' feature is. Words like 'LOVING', 'Best gift EVR' indicate high satisfaction.",
+        "sentiment": "positive",
+        "tweet": "LOVING my new Kindle2.  Named her Kendra in case u were wondering. The \"cookbook\" is THE tool cuz it tells u all the tricks!  Best gift EVR!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet mentions 'AIG scandal', which is associated with a financial crisis involving American International Group, leading to negative connotations.",
+        "sentiment": "negative",
+        "tweet": "The real AIG scandal / http://bit.ly/b82Px",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses admiration for Obama's comedic skills, uses an emoji indicating happiness, and mentions that his jokes are 'very funny', all of which contribute to a positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "Obama is quite a good comedian! check out his dinner speech on CNN :) very funny jokes.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet mentions 'funny side' and 'Great speech', which are positive words indicating a favorable sentiment towards the content.",
+        "sentiment": "positive",
+        "tweet": "' Barack Obama shows his funny side \" &gt;&gt; http://tr.im/l0gY !! Great speech..",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses a positive sentiment because it mentions liking someone and highlights their funny side, which are both favorable aspects.",
+        "sentiment": "positive",
+        "tweet": "I like this guy : ' Barack Obama shows his funny side \" &gt;&gt; http://tr.im/l0gY !!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The word 'awesome' indicates a strong positive feeling towards Obama's speech.",
+        "sentiment": "positive",
+        "tweet": "Obama's speech was pretty awesome last night! http://bit.ly/IMXUM",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet mentions 'Bill Clinton Fail - Obama Win?', which suggests a comparison between two political figures where one is failing and the other is succeeding. The use of question marks might indicate uncertainty or skepticism about this narrative, but overall, it leans towards negative sentiment regarding Bill Clinton's performance compared to Obama.",
+        "sentiment": "negative",
+        "tweet": "Reading  \"Bill Clinton Fail - Obama Win?\" http://tinyurl.com/pcyxj7",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet mentions that Obama is more popular than the U.S. among Arabs, which suggests a positive sentiment towards Obama.",
+        "sentiment": "positive",
+        "tweet": "Obama More Popular Than U.S. Among Arabs: Survey: President Barack Obama's popularity in leading Arab countries .. http://tinyurl.com/prlvqu",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses positive feelings towards Obama, using words like 'JOKES', 'haha', and stating that the user is 'in love with mr. president'. These indicate a favorable sentiment.",
+        "sentiment": "positive",
+        "tweet": "Obama's got JOKES!! haha just got to watch a bit of his after dinner speech from last night... i'm in love with mr. president ;)",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses concern about LeBron James being involved in a car accident, asking if he will be okay. The use of 'wow', 'can't believe it', and the question mark indicate worry and uncertainty, which are negative emotions.",
+        "sentiment": "negative",
+        "tweet": "LEbron james got in a car accident i guess..just heard it on evening news...wow i cant believe it..will he be ok ? http://twtad.com/69750",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses excitement about LeBron James and Carmelo Anthony being in the finals, indicating a positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "is it me or is this the best the playoffs have been in years oh yea lebron and melo in the finals",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expresses a strong opinion by stating that LeBron James is 'the best', which indicates a positive sentiment towards him.",
+        "sentiment": "positive",
+        "tweet": "@khalid0456 No, Lebron is the best",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expresses a favorable opinion about LeBron, mentioning that he likes his personality and refers to him as having 'good character'. These are positive sentiments.",
+        "sentiment": "positive",
+        "tweet": "@the_real_usher LeBron is cool.  I like his personality...he has good character.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expressed admiration for LeBron James by calling his gameplay 'Damn that niggas good', which indicates a positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "Watching Lebron highlights. Damn that niggas good",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The use of 'MURDERING' suggests a strong, possibly hyperbolic expression of frustration or anger towards LeBron's performance.",
+        "sentiment": "negative",
+        "tweet": "@Lou911 Lebron is MURDERING shit.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses admiration for LeBron's performance, calling him 'a monsta,' which indicates strong positive feelings. However, the phrase 'SMH The world ain't ready' suggests frustration or disbelief that others aren't recognizing his greatness yet. Overall, while there is a mix of emotions, the primary sentiment leans towards positive due to the praise directed at LeBron.",
+        "sentiment": "positive",
+        "tweet": "@uscsports21 LeBron is a monsta and he is only 24. SMH The world ain't ready.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet compares LeBron James to Kobe Bryant, suggesting that LeBron might surpass Kobe's legacy once his career ends. The user acknowledges Kobe as 'good,' but implies that many other players are also considered 'good,' which could mean they don't hold Kobe in the highest regard or see him as just one among equals. This comparison leans towards a positive sentiment about LeBron and possibly neutral to slightly negative regarding Kobe, depending on interpretation.",
+        "sentiment": "positive",
+        "tweet": "@cthagod when Lebron is done in the NBA he will probably be greater than Kobe. Like u said Kobe is good but there alot of 'good' players.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses support for LeBron over Kobe by saying 'LEBROn has my vote', which indicates a preference but not necessarily negative towards Kobe.",
+        "sentiment": "positive",
+        "tweet": "KOBE IS GOOD BT LEBRON HAS MY VOTE",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses a strong opinion favoring Kobe over LeBron, indicating a positive sentiment towards Kobe.",
+        "sentiment": "positive",
+        "tweet": "Kobe is the best in the world not lebron .",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user expressed excitement about accessing the World Cup 2010 with 'Damn, that's a good look!', indicating positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "@asherroth World Cup 2010 Access?? Damn, that's a good look!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses excitement about purchasing tickets for an event, indicating positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "Just bought my tickets for the 2010 FIFA World Cup in South Africa. Its going to be a great summer. http://bit.ly/9GEZI",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses mixed feelings about having to attend a long meeting but is looking forward to going home afterward.",
+        "sentiment": "positive",
+        "tweet": "I have to go to Booz Allen Hamilton for a 2hr meeting :(  But then i get to go home :)",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The word 'great' is a strong indicator of positivity. Additionally, the mention of an event ('Indian tamasha') unfolding suggests excitement or anticipation.",
+        "sentiment": "positive",
+        "tweet": "The great Indian tamasha truly will unfold from May 16, the result day for Indian General Election.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses satisfaction with their current device and mentions using it daily, indicating a positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "@crlane I have the Kindle2. I've seen pictures of the DX, but haven't seen it in person. I love my Kindle - I'm on it everyday.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses enthusiasm about a 'continual learning program with a Kindle2', using the word 'awesome'. This indicates a positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "@criticalpath Such an awesome idea - the  continual learning program with a Kindle2  http://bit.ly/1ZLfF",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user is expressing excitement about a product they love, using multiple exclamation marks and repetitions of 'LOVE'. This indicates a very positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "@faithbabywear Ooooh, what model are you getting??? I have the 40D and LOVE LOVE LOVE LOVE it!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses a positive view by using 'wonder', which conveys admiration or amazement, indicating approval and satisfaction with the elections in India.",
+        "sentiment": "positive",
+        "tweet": "The Times of India: The wonder that is India's election. http://bit.ly/p7u1H",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet mentions a 'Good video', which is a positive adjective, indicating satisfaction with the content provided by Google.",
+        "sentiment": "positive",
+        "tweet": "http://is.gd/ArUJ Good video from Google on using search options.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user mentions their skin being itchy, which indicates discomfort or irritation. The use of a sad emoji (:( ) further emphasizes negative feelings. Additionally, the mention of 'damned' lawn mowing suggests frustration with an activity that caused this issue.",
+        "sentiment": "negative",
+        "tweet": "@ambcharlesfield lol. Ah my skin is itchy :( damn lawnmowing.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user expresses frustration about having an itchy back, using exclamation marks to emphasize their discomfort.",
+        "sentiment": "negative",
+        "tweet": "itchy back!! dont ya hate it!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet mentions 'Charity Fashion Show', which is associated with positive events aimed at raising funds for good causes, contributing to a positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "Stanford Charity Fashion Show a top draw http://cli.gs/NeNuAH",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet mentions that Stanford University's Facebook profile is one of the most popular official university pages, which indicates a positive sentiment as it highlights popularity and success.",
+        "sentiment": "positive",
+        "tweet": "Stanford University?s Facebook Profile is One of the Most Popular Official University Pages - http://tinyurl.com/p5b3fl",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The word 'cool' has a positive connotation, indicating that Lyx is liked or admired.",
+        "sentiment": "positive",
+        "tweet": "Lyx is cool.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses disappointment at Danny Gokey being sent home, but also admiration and support for him as a hometown hero. The use of words like 'SOOO DISSAPOiNTED', 'YOU STiLL ROCK', and 'MY HOMETOWN HERO' indicate mixed emotions with both negative and positive sentiments.",
+        "sentiment": "negative",
+        "tweet": "SOOO DISSAPOiNTED THEY SENT DANNY GOKEY HOME... YOU STiLL ROCK ...DANNY ... MY HOMETOWN HERO !! YEAH MiLROCKEE!!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet mentions 'Adam Lambert tones down', which could imply a negative sentiment towards his style change. However, it also says 'Danny Gokey cute', which is positive. The overall sentiment might be mixed or neutral.",
+        "sentiment": "negative",
+        "tweet": "RT @PassionModel 'American Idol' fashion: Adam Lambert tones down, Danny Gokey cute ... http://cli.gs/7JWSHV",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expressed strong affection towards Danny Gokey using words like 'love' and added a smiley emoji, indicating positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "@dannygokey I love you DANNY GOKEY!! :)",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expressed feeling very tired because they did not sleep well, indicating a negative emotional state.",
+        "sentiment": "negative",
+        "tweet": "so tired. i didn't sleep well at all last night.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user mentions boarding a plane, which is neutral on its own, but then uses 'Blech,' indicating dissatisfaction with the long flight.",
+        "sentiment": "negative",
+        "tweet": "Boarding plane for San Francisco in 1 hour; 6 hr flight. Blech.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user mentions their back hurting after a trip to San Francisco, which indicates discomfort or pain.",
+        "sentiment": "negative",
+        "tweet": "bonjour San Francisco. My back hurts from last night..",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses happiness about spending time with family, using words like 'best girl', 'wonderful', which are positive indicators.",
+        "sentiment": "positive",
+        "tweet": "With my best girl for a few more hours in San francisco. Mmmmmfamily is wonderful!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet contains strong language ('F***') which indicates frustration or anger. The phrase 'go home' suggests dissatisfaction with a situation, possibly implying that if things aren't done right (as in the first part), it's better to leave. Overall, this conveys a negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "F*** up big, or go home - AIG",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user mentions that they went to see a Star Trek movie, which is generally associated with being an enjoyable experience for fans of the franchise. The word 'satisfying' indicates that the user felt fulfilled or content after watching it.",
+        "sentiment": "positive",
+        "tweet": "Went to see the Star Trek movie last night.  Very satisfying.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expresses excitement about seeing Star Trek tonight by using words like 'can't wait' and exclamation marks, indicating a positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "I can't wait, going to see star trek tonight!!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses a strong positive opinion about Star Trek by using superlatives like 'as good as everyone said', indicating satisfaction.",
+        "sentiment": "positive",
+        "tweet": "Star Trek was as good as everyone said!!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expresses a strong positive emotion by stating they are 'loving' something, which indicates satisfaction and enjoyment.",
+        "sentiment": "positive",
+        "tweet": "am loving new malcolm gladwell book - outliers",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expresses a strong endorsement by stating they 'highly recommend' the book and indicate their intention to read more from the same author, which shows enthusiasm.",
+        "sentiment": "positive",
+        "tweet": "I highly recommend Malcolm Gladwell's 'The Tipping Point.' My next audiobook will probably be one of his as well.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet uses strong language like 'genius', but it's followed by critical statements about Malcolm Gladwell being an 'idiot'. The overall tone suggests dissatisfaction and criticism, indicating negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "Malcolm Gladwell is a genius at tricking people into not realizing he's a fucking idiot",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet uses strong language such as 'pretenious', 'annoying', and the use of profanity ('cunt') to express dislike towards Malcolm Gladwell. The phrase 'cant read his shit' further shows contempt for his work, indicating a negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "@sportsguy33 hey no offense but malcolm gladwell is a pretenious, annoying cunt and he brings you down. cant read his shit",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user is sharing a link to an article written by Malcolm Gladwell, which they describe as 'Great'. The use of the word 'great' indicates a positive sentiment towards the content being shared.",
+        "sentiment": "positive",
+        "tweet": "RT @clashmore: http://bit.ly/SOYv7  Great article by Malcolm Gladwell.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expresses a strong positive feeling towards Malcolm Gladwell by stating they 'seriously underestimated' him, indicating an increase in their admiration or appreciation after getting to know more about him. The desire to meet him further emphasizes the positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "I seriously underestimated Malcolm Gladwell.  I want to meet this dude.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expresses frustration towards Comcast, mentioning that their services (cable, internet, & phone) are all down. The use of 'hate' and the exclamation mark indicate strong negative emotions.",
+        "sentiment": "negative",
+        "tweet": "i hate comcast right now. everything is down cable internet &amp; phone....ughh what am i to do",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The word 'sucks' has a strongly negative connotation, indicating dissatisfaction.",
+        "sentiment": "negative",
+        "tweet": "Comcast sucks.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user expresses a strong dislike towards Comcast, indicating that not having to interact with them anymore would be a significant positive event for them.",
+        "sentiment": "positive",
+        "tweet": "The day I never have to deal with Comcast again will rank as one of the best days of my life.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses frustration towards Comcast by questioning if they failed again, indicating a negative experience.",
+        "sentiment": "negative",
+        "tweet": "@Dommm did comcast fail again??",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user expresses frustration about being limited by Twitter's API.",
+        "sentiment": "negative",
+        "tweet": "curses the Twitter API limit",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses frustration regarding the limitations and access issues with Twitter's API, as mentioned by Dave Winer. The use of words like 'screams', 'lack', 'limitations', and 'access throttles' indicates a negative sentiment towards the situation.",
+        "sentiment": "negative",
+        "tweet": "Now I can see why Dave Winer screams about lack of Twitter API, its limitations and access throttles!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user expressed frustration with 'Twitter API', using words like 'crazy'. This indicates a negative emotion.",
+        "sentiment": "negative",
+        "tweet": "Arg. Twitter API is making me crazy.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a positive sentiment towards Wolfram Alpha, comparing it favorably to Google and using words like 'loving' which indicate satisfaction.",
+        "sentiment": "positive",
+        "tweet": "I'm really loving the new search site Wolfram/Alpha. Makes Google seem so ... quaint. http://www72.wolframalpha.com/",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses frustration with Wolfram Alpha by using strong language like 'SUCKS' and calling it 'totally useless.' The user compares it unfavorably to Google and Wikipedia. This indicates a negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "#wolfram Alpha SUCKS! Even for researchers the information provided is less than you can get from #google or #wikipedia, totally useless!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user expresses excitement about going to the Nike factory, which indicates a positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "Off to the NIKE factory!!!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet mentions that the new Nike Muppet commercials are 'pretty cute,' which is a positive adjective indicating enjoyment or approval of the commercials. The second part, asking why they live together again, could be interpreted in different ways depending on context. However, without additional information suggesting negativity, it's reasonable to assume this adds a light-hearted touch rather than expressing dissatisfaction. Overall, the sentiment leans towards positive.",
+        "sentiment": "positive",
+        "tweet": "New nike muppet commercials are pretty cute. Why do we live together again?",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expresses excitement about something ('awesome') but then shows disappointment because it's associated with Nike, which might be a brand they don't like. The overall sentiment is negative due to the expressed dissatisfaction.",
+        "sentiment": "negative",
+        "tweet": "@Fraggle312 oh those are awesome! i so wish they weren't owned by nike :(",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses excitement and anticipation about seeing a concert by Nine Inch Nails (NIN) on Friday at the Shoreline Amphitheatre. The use of 'AWESOME!!!', multiple exclamation marks, and phrases like 'Can't wait' indicate strong positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "@tonyhawk http://twitpic.com/5c7uj - AWESOME!!! Seeing the show Friday at the Shoreline Amphitheatre. Never seen NIN before. Can't wait. ...",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expresses frustration about encountering a 'weka bug', which is likely a software issue they had trouble resolving. They mention spending nearly two hours trying to figure it out, indicating their time was wasted. The use of words like 'crappy me' suggests self-deprecation and dissatisfaction with the situation.",
+        "sentiment": "negative",
+        "tweet": "arhh, It's weka bug. = =\" and I spent almost two hours to find that out. crappy me",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses satisfaction with their current camera (Canon EOS Rebel T3i/50D) but also mentions wanting an upgrade to the higher-end Canon EOS 5D Mark II. The use of 'love' indicates positive sentiment towards the current device, while expressing a desire for something better doesn't necessarily negate that positivity.",
+        "sentiment": "positive",
+        "tweet": "@mitzs hey bud :) np I do so love my 50D, although I'd love a 5D mkII more",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses excitement about acquiring a newCanon EOS Rebel T3i (referred to as '50D') camera for the office, which is typically seen as a positive development.",
+        "sentiment": "positive",
+        "tweet": "@jonduenas @robynlyn just got us a 50D for the office. :D",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expresses excitement about their new camera, using words like 'beautiful' and 'seriously awesome', which indicate a positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "Just picked up my new Canon 50D...it's beautiful!!  Prepare for some seriously awesome photography!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expresses excitement about their newCanon 50D, using multiple 'love's to emphasize their positive feelings.",
+        "sentiment": "positive",
+        "tweet": "Just got my new toy. Canon 50D. Love love love it!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet mentions learning about lambda calculus followed by a smiley face emoji ':)'. The use of a smiley indicates a positive emotion, suggesting that the person is happy or excited about their experience with lambda calculus.",
+        "sentiment": "positive",
+        "tweet": "Learning about lambda calculus :)",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expressed excitement about their move by using an exclamation mark, indicating a positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "I'm moving to East Palo Alto!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expressed appreciation for a class session, used 'You Rock!', which is positive.",
+        "sentiment": "positive",
+        "tweet": "@ atebits I just finished watching your Stanford iPhone Class session. I really appreciate it. You Rock!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses appreciation for someone's advice, indicating a positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "@jktweet Hi! Just saw your Stanford talk and really liked your advice. Just saying Hi from Singapore (yes the videos do get around)",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses excitement about watching the Lakers play tonight, using multiple exclamation marks to convey enthusiasm.",
+        "sentiment": "positive",
+        "tweet": "LAKERS tonight let's go!!!!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The use of 'kick ass' suggests a confident prediction that the Lakers will perform well against the Nuggets, indicating a positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "Will the Lakers kick the Nuggets ass tonight?",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses concern about North Korea being 'in trouble', which indicates a negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "Oooooooh... North Korea is in troubleeeee! http://bit.ly/19epAH",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses concern and alarm about North Korea's actions, indicating a negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "Wat the heck is North Korea doing!!??!! They just conducted powerful nuclear tests! Follow the link: http://www.msnbc.msn.com/id/30921379",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses frustration towards Obama's policies regarding North Korea.",
+        "sentiment": "negative",
+        "tweet": "Listening to Obama... Friggin North Korea...",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet mentions 'three monkeys', which is a metaphor often used to represent silence or ignoring something important. The mention of political figures like Biden and Pelosi could imply dissatisfaction with their actions or policies. However, without more context, it's hard to determine the exact sentiment.",
+        "sentiment": "negative",
+        "tweet": "I just realized we three monkeys in the white Obama.Biden,Pelosi . Sarah Palin 2012",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a desire for Pelosi to remain in China indefinitely, which suggests dissatisfaction or frustration towards her actions.",
+        "sentiment": "negative",
+        "tweet": "@foxnews Pelosi should stay in China and never come back.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user expresses strong dissatisfaction towards Nancy Pelosi's speech, using words like 'worst', which indicates a negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "Nancy Pelosi gave the worst commencement speech I've ever heard. Yes I'm still bitter about this",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user expresses frustration about being bitten by insects multiple times, using words like 'ugh', 'stupid', and 'grr'. These expressions indicate a negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "ugh. the amount of times these stupid insects have bitten me. Grr..",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet uses words like 'Prettiest' which is a strong positive adjective, indicating admiration or appreciation for the pink katydids. The use of 'EVER' emphasizes that this is one of the most beautiful insects they've seen. Additionally, sharing a link suggests enthusiasm and wanting to share something pleasant with others.",
+        "sentiment": "positive",
+        "tweet": "Prettiest insects EVER - Pink Katydids: http://bit.ly/2Upw2p",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user mentions being 'barraged by a horde of insects', which indicates an overwhelming situation, and describes it as 'so scary'. These words convey fear and discomfort, indicating a negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "Just got barraged by a horde of insects hungry for my kitchen light. So scary.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user expressed satisfaction by using emojis like ':D' and ';)', indicating a positive experience with their meal.",
+        "sentiment": "positive",
+        "tweet": "Just had McDonalds for dinner. :D It was goooood. Big Mac Meal. ;)",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet uses all caps, exclamation marks, and emojis which indicate excitement or happiness.",
+        "sentiment": "positive",
+        "tweet": "AHH YES LOL IMA TELL MY HUBBY TO GO GET ME SUM MCDONALDS =]",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user mentions stopping for lunch at McDonald's, which is a neutral statement on its own. However, they express excitement with 'Chicken Nuggetssss!' and use an emoji ':)' along with 'yummmmmy', indicating satisfaction and enjoyment of their meal.",
+        "sentiment": "positive",
+        "tweet": "Stopped to have lunch at McDonalds. Chicken Nuggetssss! :) yummmmmy.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expresses a strong desire to eat at McDonald's, using 'a lot', which indicates enthusiasm.",
+        "sentiment": "positive",
+        "tweet": "Could go for a lot of McDonalds. i mean A LOT.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user mentions that their exam went well, which is a positive statement. They also express gratitude towards someone named Leonie for her prayers working out, indicating satisfaction and happiness.",
+        "sentiment": "positive",
+        "tweet": "my exam went good. @HelloLeonie: your prayers worked (:",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user mentions having only one exam left and expresses happiness about it using 'so happy' and a smiley face ':D'. This indicates a positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "Only one exam left, and i am so happy for it :D",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expressed concern about failing an exam during a math review session.",
+        "sentiment": "negative",
+        "tweet": "Math review. Im going to fail the exam.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses strong approval for Colin Powell, calling him 'a man of honor' who 'served our country proudly.' It also criticizes Dick Cheney by saying he should 'shut the hell up and go home,' which indicates dissatisfaction with his actions or statements. The overall sentiment is mixed because it contains both positive and negative elements.",
+        "sentiment": "negative",
+        "tweet": "Colin Powell rocked yesterday on CBS. Cheney needs to shut the hell up and go home.Powell is a man of Honor and served our country proudly",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user's tweet expresses a clear stance against Cheney, indicating dissatisfaction or disagreement.",
+        "sentiment": "negative",
+        "tweet": "obviously not siding with Cheney here: http://bit.ly/19j2d",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The word 'hilarious' is a strong indicator of positive sentiment, as it conveys laughter and enjoyment.",
+        "sentiment": "positive",
+        "tweet": "Absolutely hilarious!!! from @mashable:  http://bit.ly/bccWt",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses gratitude and uses positive language like 'You Rock!' which indicates a positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "@mashable I never did thank you for including me in your Top 100 Twitter Authors! You Rock! (&amp; I New Wave :-D) http://bit.ly/EOrFV",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet contains words like 'Awesome', which is a positive adjective, and it's sharing a resource related to web design, indicating satisfaction or excitement about the topic.",
+        "sentiment": "positive",
+        "tweet": "RT @shrop: Awesome JQuery reference book for Coda! http://www.macpeeps.com/coda/ #webdesign",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses frustration or anxiety about not being able to reach someone at Goodby Silverstein despite sending many emails. The use of 'like crazy' indicates the sender is putting in significant effort, but there's no positive outcome mentioned. This suggests a negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "I've been sending e-mails like crazy today to my contacts...does anyone have a contact at Goodby SIlverstein...I'd love to speak to them",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expressed enjoyment of Goodby, Silverstein's new website by saying 'I enjoy it,' which indicates a positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "Goodby, Silverstein's new site... http://www.goodbysilverstein.com/ I enjoy it.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses excitement about receiving free G2 devices and a month of unlimited service, indicating a positive experience.",
+        "sentiment": "positive",
+        "tweet": "Wow everyone at the Google I/O conference got free G2's with a month of unlimited service",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expresses excitement about receiving a free Google Android phone, specifically mentioning it's from the I/O conference and refers to it as 'the G2!'. This indicates positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "@vkerkez dood I got a free google android phone at the I/O conference. The G2!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user mentions that 'the G2 is amazing', which indicates satisfaction. They also state it's a 'HUGE improvement over the G1', showing positive sentiment towards the product upgrade.",
+        "sentiment": "positive",
+        "tweet": "@Orli the G2 is amazing btw, a HUGE improvement over the G1",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses excitement with words like 'excited', the smiley face ':)', and mentions of positive things coming ('Lots of great stuff to come!'). These elements indicate a positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "HTML 5 Demos! Lots of great stuff to come! Yes, I'm excited. :) http://htmlfive.appspot.com #io2009 #googleio",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses excitement and happiness towards Google, using words like 'Yay!', 'Happy', and stating that they 'love Google'. These are strong indicators of a positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "@googleio http://twitpic.com/62shi - Yay! Happy place! Place place!  I love Google!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses a positive opinion about bringing 3D graphics to browsers, using words like 'Very nice' and 'Funfun', which indicate satisfaction.",
+        "sentiment": "positive",
+        "tweet": "#GoogleIO | O3D - Bringing 3d graphics to the browser. Very nice tbh. Funfun.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The word 'awesome' is a strong positive adjective, indicating that the user holds a favorable view of the viral marketing campaign mentioned in the tweet.",
+        "sentiment": "positive",
+        "tweet": "Awesome viral marketing for \"Funny People\" http://www.nbc.com/yo-teach/",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expresses frustration about watching a movie they didn't want to see, questioning who funds such films.",
+        "sentiment": "negative",
+        "tweet": "saw night at the museum out of sheer desperation. who is funding these movies?",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user expresses a strong positive opinion about 'Night at the Museum 2', using enthusiastic language such as 'Pretty furkin good'.",
+        "sentiment": "positive",
+        "tweet": "Night At The Museum 2? Pretty furkin good.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet mentions 'giggling', which indicates a positive emotional response to watching 'Night at the Museum'. The use of an emoji (\ud83d\ude0a) further reinforces a happy or amused sentiment.",
+        "sentiment": "positive",
+        "tweet": "Watching Night at the Museum - giggling.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses a mixed sentiment towards two movies. The user enjoyed 'Star Trek,' describing it as 'amazing,' which is positive. However, they were unimpressed with 'Night at the Museum,' using the word 'eh,' indicating dissatisfaction or neutrality. Overall, since there's both positivity and negativity, but leaning more negative due to the latter part of the tweet.",
+        "sentiment": "negative",
+        "tweet": "Back from seeing 'Star Trek' and 'Night at the Museum.' 'Star Trek' was amazing, but 'Night at the Museum' was; eh.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user expressed enjoyment by stating they just watched 'Night at the Museum 2' and found it 'so stinkin cute.' The use of words like 'cute' indicates a positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "just watched night at the museum 2! so stinkin cute!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expressed strong enthusiasm for 'Night at the Museum 2', using words like 'AWESOME!' and stating it's much better than the first part. They also look forward to watching another movie, indicating a positive experience.",
+        "sentiment": "positive",
+        "tweet": "So, Night at the Museum 2 was AWESOME! Much better than part 1. Next weekend we'll see Up.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expressed enjoyment by stating they 'loved' the movie, indicating a positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "saw the new Night at the Museum and i loved it. Next is to go see UP in 3D",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses disappointment towards GM, questioning their ability to produce cars that align with the White House's expectations. The use of 'shame' indicates a negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "It is a shame about GM. What if they are forced to make only cars the White House THINKS will sell? What do you think?",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user is expressing dissatisfaction regarding several companies including General Motors (GM), American International Group (AIG), and Lehman Brothers. The phrase 'not too happy about' clearly indicates a negative sentiment towards these entities.",
+        "sentiment": "negative",
+        "tweet": "As u may have noticed, not too happy about the GM situation, nor AIG, Lehman, et al",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user expressed a mixed sentiment by saying 'good riddance,' which is positive, but also mentioned feeling 'sad,' indicating negativity.",
+        "sentiment": "negative",
+        "tweet": "@Pittstock $GM good riddance.  sad though.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses dissatisfaction with government motors vehicles and the decision to never buy them again.",
+        "sentiment": "negative",
+        "tweet": "I Will NEVER Buy a Government Motors Vehicle: Until just recently, I drove GM cars. Since 1988, when I bought a .. http://tinyurl.com/lulsw8",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The use of 'stupid' indicates a strong negative opinion about having an older figure from Coca-Cola on the GM board.",
+        "sentiment": "negative",
+        "tweet": "Having the old Coca-Cola guy on the GM board is stupid has heck! #tcot #ala",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses frustration with the UAW, using strong language like 'fucking', which indicates a negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "#RantsAndRaves The worst thing about GM (concord / pleasant hill / martinez): is the fucking UAW. ..   http://buzzup.com/4ueb",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet uses a well-known saying about teaching someone to fish as opposed to giving them a fish, which is generally seen as positive advice on self-sufficiency. However, the second part of the tweet introduces 'Buy him GM,' where GM likely refers to General Motors or genetically modified organisms. The phrase 'u F**K him over for good' suggests that buying someone GM leads to a negative outcome. This contrast between the initial positive message and the subsequent negative consequence creates an overall negative sentiment in the tweet.",
+        "sentiment": "negative",
+        "tweet": "Give a man a fish, u feed him for the day. Teach him to fish, u feed him for life. Buy him GM, and u F**K him over for good.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses frustration with 'Billions wasted' and refers to the situation as 'bullshit,' indicating a negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "The more I hear about this GM thing the more angry I get. Billions wasted, more bullshit. All for something like 40k employees and all the..",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user mentions owning a GM car but compares its quality unfavorably to Honda, indicating dissatisfaction with GM's product.",
+        "sentiment": "negative",
+        "tweet": "@QuantTrader i own a GM car and it is junk as far as quality compared to a honda",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses sadness about General Motors going bankrupt.",
+        "sentiment": "negative",
+        "tweet": "sad day...bankrupt GM",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user expresses feeling 'upset' and mentions that their life feels 'screwed up', which indicates negative emotions.",
+        "sentiment": "negative",
+        "tweet": "is upset about the whole GM thing. life as i know it is so screwed up",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses frustration towards Time Warner's cable services, using strong language that conveys anger and dissatisfaction.",
+        "sentiment": "negative",
+        "tweet": "whoever is running time warner needs to be repeatedly raped by a rhino so they understand the consequences of putting out shitty cable svcs",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user mentions that their connection was down, which is frustrating, but they are still joining whatever event or activity WFTB refers to. The use of 'boo' indicates mild dissatisfaction towards Time Warner for the connectivity issue.",
+        "sentiment": "negative",
+        "tweet": "#WFTB Joining a bit late. My connection was down (boo time warner)",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user compares two internet providers, Cox and Time Warner (TW). They mention that Cox is cheaper with a 'B' rating, while TW is more expensive with a 'C' rating. The comparison highlights Cox as the better option due to lower cost and higher rating.",
+        "sentiment": "positive",
+        "tweet": "Cox or Time Warner?  Cox is cheaper and gets a B on dslreports.  TW is more expensive and gets a C.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user expresses anger towards Time Warner's phone promotions using strong language like 'furious', indicating a negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "i am furious with time warner and their phone promotions!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user mentions having a good experience at Chick-fil-A with friends, which is positive. However, they express frustration about their internet being slow or down due to Time Warner, which adds a negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "Just got home from chick-fil-a with the boys. Damn my internets down =( stupid time warner",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet uses a rhetorical question to express dissatisfaction with Time Warner Cable, indicating frustration.",
+        "sentiment": "negative",
+        "tweet": "could time-warner cable suck more?  NO.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user expresses frustration towards Time Warner regarding their internet issues, using strong language like 'pissed'. This indicates a negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "Pissed at Time Warner for causin me to have slow internet problems",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet mentions 'Time Warner problems', which suggests that the user is experiencing issues with their service provider. The use of 'Ummm' indicates hesitation or uncertainty, and asking about problems implies a negative experience.",
+        "sentiment": "negative",
+        "tweet": "@sportsguy33 Ummm, having some Time Warner problems?",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses frustration with Time Warner's service, indicating a negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "You guys see this?  Why does Time Warner have to suck so much ass?  Really wish I could get U-Verse at my apartment. http://bit.ly/s594j",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses dissatisfaction with Time Warner's customer service, mentioning 'unhelpful phone operators', 'superslow on-site service', and calling it 'crap'. These are all negative sentiments.",
+        "sentiment": "negative",
+        "tweet": "RT @sportsguy33 The upside to Time Warner: unhelpful phone operators   superslow on-site service. Crap, that's not an upside.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet is a retweet of another user's comment about a new Time Warner slogan. The slogan itself seems to be critical or sarcastic because it implies that people would prefer the days before cable, which suggests dissatisfaction with current offerings. Therefore, the sentiment expressed in this tweet is negative.",
+        "sentiment": "negative",
+        "tweet": "RT @sportsguy33: New Time Warner slogan: \"Time Warner, where we make you long for the days before cable.\"",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses frustration with Time Warner's service causing slow loading times on Facebook and the temptation to switch providers.",
+        "sentiment": "negative",
+        "tweet": "confirmed: it's Time Warner's fault, not Facebook's, that fb is taking about 3 minutes to load. so tempted to switch to verizon =/",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user mentions 'epic fail', which indicates a strong negative opinion about Time Warner.",
+        "sentiment": "negative",
+        "tweet": "@sportsguy33 Time Warner = epic fail",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a negative sentiment because the user finds it saddening and compares something scary to an even scarier situation, indicating dissatisfaction or concern.",
+        "sentiment": "negative",
+        "tweet": "I know. How sad is that?  RT @caseymercier: 1st day of hurricane season. That's less scarey than govt taking over GM.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet mentions 'Bankruptcy', which generally has a negative connotation as it indicates financial trouble for GM.",
+        "sentiment": "negative",
+        "tweet": "GM files Bankruptcy, not a good sign...",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet mentions that 'yankees won' which indicates a positive outcome for one team, while also stating that 'mets lost', showing a negative result for another team. However, the overall sentiment is determined by the phrase 'its a good day.', which conveys positivity regardless of individual outcomes.",
+        "sentiment": "positive",
+        "tweet": "yankees won mets lost. its a good day.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet mentions that their dental appointment was 'actually quite enjoyable', which indicates a pleasant experience despite possibly having initial reservations about going to the dentist.",
+        "sentiment": "positive",
+        "tweet": "My dentist appt today was actually quite enjoyable.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The word 'hate' indicates a strong dislike towards something, which conveys a negative emotion.",
+        "sentiment": "negative",
+        "tweet": "I hate the effing dentist.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user expresses a strong dislike for visiting the dentist by using 'hate', which indicates a negative emotion.",
+        "sentiment": "negative",
+        "tweet": "@kirstiealley I hate going to the dentist.. !!!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user expresses a strong dislike for dentists by saying 'I hate the dentist.' Additionally, they question who invented dentists, which further indicates frustration or aversion towards dental professionals.",
+        "sentiment": "negative",
+        "tweet": "i hate the dentist....who invented them anyways?",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses dissatisfaction about a dentist's office being cold, indicating a negative experience.",
+        "sentiment": "negative",
+        "tweet": "this dentist's office is cold :/",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user expressed excitement about applying for a job at Safeway by using multiple exclamation marks and an enthusiastic word 'Yeeeee!'. This indicates a positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "Just applied at Safeway!(: Yeeeee!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expresses frustration about their experience at Safeway, using strong language like 'nightmare' which indicates dissatisfaction.",
+        "sentiment": "negative",
+        "tweet": "@ Safeway. Place is a nightmare right now. Bumming.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user expresses strong dislike for Safeway Select Green Tea Ice Cream by using words like 'HATE', which indicates negative sentiment. They mention buying two cartons and calling it a waste of money, further emphasizing their dissatisfaction.",
+        "sentiment": "negative",
+        "tweet": "HATE safeway select green tea icecream! bought two cartons, what a waste of money.  &gt;_&lt;",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses gratitude and excitement towards Nike, using positive language like 'rocks', 'super grateful', and 'BEYOND!' along with a smiley emoji. The overall sentiment is clearly positive.",
+        "sentiment": "positive",
+        "tweet": "Nike rocks. I'm super grateful for what I've done with them :) &amp; the European Division of NIKE is BEYOND! @whitSTYLES @muchasmuertes",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet mentions that using Nike products has been 'very addictive', which suggests a strong positive experience.",
+        "sentiment": "positive",
+        "tweet": "@evelynbyrne have you tried Nike  ? V. addictive.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expresses interest in a product by stating it 'looks very interesting', which indicates a favorable view.",
+        "sentiment": "positive",
+        "tweet": "The Nike Training Club (beta) iPhone app looks very interesting.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expressed frustration about their jQuery not appearing in Safari, using multiple exclamation marks and an aggressive tone.",
+        "sentiment": "negative",
+        "tweet": "argghhhh why won't  my jquery appear in safari bad safari !!!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a strong affection for jQuery by stating 'forever in love with jQuery' and comparing it to marriage ('marry it'). The use of humor and playful language suggests a positive sentiment towards the technology.",
+        "sentiment": "positive",
+        "tweet": "I'm ready to drop the pretenses, I am forever in love with jQuery, and I want to marry it. Sorry ladies, this nerd is jquery.spokenFor.js",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet mentions 'A great weekend read', which indicates a positive sentiment towards the content shared.",
+        "sentiment": "positive",
+        "tweet": "SUPER INVESTORS: A great weekend read here from Warren Buffet. Oldie, but a goodie. http://tinyurl.com/oqxgga",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user is expressing enjoyment of a book by Michael Palin and recommending biographies of Warren Buffett and Nelson Mandela. This indicates a positive sentiment as they are sharing something they find valuable and enjoyable.",
+        "sentiment": "positive",
+        "tweet": "reading Michael Palin book, The Python Years...great book. I also recommend Warren Buffet &amp; Nelson Mandela's bio",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses a positive sentiment because the user is willing to attend Notre Dame and mentions that it's a good school, being close to someone they care about (Dan), and enjoying the situation. These are all indicators of satisfaction and positivity.",
+        "sentiment": "positive",
+        "tweet": "I mean, I'm down with Notre Dame if I have to.  It's a good school, I'd be closer to Dan, I'd enjoy it.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses frustration with the Time/ Warner DVR system despite using it for many years, indicating dissatisfaction.",
+        "sentiment": "negative",
+        "tweet": "I can't watch TV without a Tivo.  And after all these years, the Time/Warner DVR  STILL sucks. http://www.davehitt.com/march03/twdvr.html",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses strong agreement with Roger Federer being considered the greatest tennis player ever, using superlatives like 'THE best'. The use of capitalization emphasizes this sentiment and conveys a positive view towards Federer.",
+        "sentiment": "positive",
+        "tweet": "I'd say some sports writers are idiots for saying Roger Federer is one of the best ever in Tennis.  Roger Federer is THE best ever in Tennis",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expresses a preference for their old device, indicating satisfaction with it ('still love'), which is positive. However, they also mention that using the new device doesn't feel natural and express longing for something else ('miss the Bloomingdale ads'). This shows some dissatisfaction or negative feelings towards the current situation.",
+        "sentiment": "negative",
+        "tweet": "I still love my Kindle2 but reading The New York Times on it does not feel natural. I miss the Bloomingdale ads.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user expresses a strong preference for their Kindle, indicating satisfaction with its use as an alternative to physical books.",
+        "sentiment": "positive",
+        "tweet": "I love my Kindle2. No more stacks of books to trip over on the way to the loo.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses mixed feelings about today's keynote being impressive ('rocked') but also frustration with AT&T's actions described as 'shit on us'. The overall sentiment leans towards negative due to the strong dissatisfaction expressed regarding AT&T.",
+        "sentiment": "negative",
+        "tweet": "Although today's keynote rocked, for every great announcement, AT&amp;T shit on us just a little bit more.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses frustration about being tied to AT&T due to an iPhone dependency, indicating negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "@sheridanmarfil - its not so much my obsession with cell phones, but the iphone!  i'm a slave to at&amp;t forever because of it. :)",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet mentions 'more fun', which indicates a positive experience with Fuzzball compared to AT&T.",
+        "sentiment": "positive",
+        "tweet": "Fuzzball is more fun than AT&amp;T ;P http://fuzz-ball.com/twitter",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses dissatisfaction towards AT&T by stating it's a 'good day to dislike', which indicates negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "Today is a good day to dislike AT&amp;T. Vote out of office indeed, @danielpunkass",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses excitement about receiving a Wave Sandbox invite, which is positive. The user mentions being 'extra excited,' indicating strong positive emotions. Although they mention having class now as a downside, the overall tone remains upbeat and enthusiastic.",
+        "sentiment": "positive",
+        "tweet": "GOT MY WAVE SANDBOX INVITE! Extra excited! Too bad I have class now... but I'll play with it soon enough! #io2009 #wave",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user mentions that 'summize has gone down', which indicates a problem, suggesting frustration or concern about the service being unavailable. Additionally, they express uncertainty with 'perhaps?', implying doubt or confusion about why it's happening. Overall, this conveys a negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "looks like summize has gone down. too many tweets from WWDC perhaps?",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses gratitude and excitement with words like 'Thanks', 'so much', 'happy', 'surprised', and 'fabulous'. The use of multiple exclamation points and a smiley face emoji further emphasizes the positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "@sklososky Thanks so much!!! ...from one of your *very* happy Kindle2 winners ; ) I was so surprised, fabulous. Thank you! Best, Kathleen",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses dissatisfaction with Apple, specifically mentioning disliking them and expressing frustration about the lack of a video recorder app on the iPhone 3GS.",
+        "sentiment": "negative",
+        "tweet": "Man I kinda dislike Apple right now. Case in point: the iPhone 3GS. Wish there was a video recorder app. Please?? http://bit.ly/DZm1T",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses satisfaction with the product, mentioning positive aspects like the physical feel of the device, nice font, and quick page turns. The only minor criticism is about the user interface being a bit clunky, but overall the sentiment is positive.",
+        "sentiment": "positive",
+        "tweet": "@cwong08 I have a Kindle2 (&amp; Sony PRS-500). Like it! Physical device feels good. Font is nice. Pg turns are snappy enuf. UI a little klunky.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user is expressing a positive opinion about the Kindle2 being the best eReader while also seeking information on its availability in the UK. The sentiment leans towards positive as they are highlighting a favorable aspect of the product.",
+        "sentiment": "positive",
+        "tweet": "The #Kindle2 seems the best eReader, but will it work in the UK and where can I get one?",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user mentions having a 'google addiction', which is generally seen as negative because it implies excessive use or dependence on Google services. However, the tweet ends with laughter ('Hahaha'), indicating humor and possibly self-awareness without strong negativity.",
+        "sentiment": "negative",
+        "tweet": "I have a google addiction. Thank you for pointing that out, @annamartin123. Hahaha.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses frustration towards Google for sending an unusable Visa card. The use of 'bastards!' and questioning why they are being screwed over indicates negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "dearest @google, you rich bastards! the VISA card you sent me doesn't work. why screw a little guy like me?",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses excitement about attending an event featuring two popular chefs, indicating a positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "Excited about seeing Bobby Flay and Guy Fieri tomorrow at the Great American Food &amp; Music Fest!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses excitement about attending a show by Bobby Flay tomorrow, mentions eating and drinking, and ends with 'gonna be good,' indicating positive anticipation.",
+        "sentiment": "positive",
+        "tweet": "Gonna go see Bobby Flay 2moro at Shoreline. Eat and drink. Gonna be good.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses excitement about attending a food and music festival, mentioning specific items like Katz's pastrami and Bobby Flay, which are positive references.",
+        "sentiment": "positive",
+        "tweet": "can't wait for the great american food and music festival at shoreline tomorrow.  mmm...katz pastrami and bobby flay. yes please.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet describes an enjoyable experience with family, meeting a celebrity chef, but ends on a minor downside of losing one's voice. The overall sentiment is positive despite the slight inconvenience.",
+        "sentiment": "positive",
+        "tweet": "My dad was in NY for a day, we ate at MESA grill last night and met Bobby Flay. So much fun, except I completely lost my voice today.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user mentions 'fighting with LaTeX', which indicates frustration or struggle.",
+        "sentiment": "negative",
+        "tweet": "Fighting with LaTex. Again...",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses strong affection towards '@Iheartseverus', using words like 'love' and multiple exclamation marks, which indicate a positive sentiment. The mention of 'Latex = the devil' could be interpreted as frustration or dislike towards latex, but since it's not directed at the person being addressed, it doesn't affect the overall positive tone.",
+        "sentiment": "positive",
+        "tweet": "@Iheartseverus we love you too and don't want you to die!!!!!!  Latex = the devil",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses frustration with Inkscape and LaTeX not working properly for seven hours, indicating a negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "7 hours. 7 hours of inkscape crashing, normally solid as a rock. 7 hours of LaTeX complaining at the slightest thing. I can't take any more.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The use of 'shit's hitting the fan' is a strong metaphor indicating something bad happening, which suggests negative feelings about the situation.",
+        "sentiment": "negative",
+        "tweet": "Shit's hitting the fan in Iran...craziness indeed #iranelection",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses mixed feelings but leans towards negative due to the mention of 'Iran may implode' which indicates concern or negativity, while other parts are neutral or positive.",
+        "sentiment": "negative",
+        "tweet": "Monday already. Iran may implode. Kitchen is a disaster. @annagoss seems happy. @sebulous had a nice weekend and @goldpanda is great. whoop.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user is expressing excitement about trying new recipes, specifically mentioning a chef they appreciate (Bobby Flay). The use of words like 'great' and the gratitude expressed ('Thanks Bobby') indicate positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "getting ready to test out some burger receipes this weekend. Bobby Flay has some great receipes to try. Thanks Bobby.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses strong affection for Bobby Flay, indicating positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "i lam so in love with Bobby Flay... he is my favorite. RT @terrysimpson: @bflay you need a place in Phoenix. We have great peppers here!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses frustration with creating a LaTeX file that didn't go as planned.",
+        "sentiment": "negative",
+        "tweet": "I just created my first LaTeX file from scratch. That didn't work out very well. (See @amandabittner , it's a great time waster)",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user expresses satisfaction with Linux, comparing it favorably to Windows, which indicates a positive sentiment. Additionally, they are looking forward to using a specific LaTeX editor, further showing enthusiasm and positivity.",
+        "sentiment": "positive",
+        "tweet": "using Linux and loving it - so much nicer than windows... Looking forward to using the wysiwyg latex editor!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expresses dissatisfaction with how other typesetting systems compare to LaTeX after extensive use of it.",
+        "sentiment": "negative",
+        "tweet": "After using LaTeX a lot, any other typeset mathematics just looks hideous.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses strong dislike towards several software programs (Word, Pages, and LaTeX) using the word 'hate' multiple times. The repetition emphasizes the negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "On that note, I hate Word. I hate Pages. I hate LaTeX. There, I said it. I hate LaTeX. All you TEXN3RDS can come kill me now.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user expresses excitement about returning to using LaTeX, which is indicated by their use of 'Ahhh...' and the heart symbol '&lt;3'. These expressions convey positive emotions.",
+        "sentiment": "positive",
+        "tweet": "Ahhh... back in a *real* text editing environment. I &lt;3 LaTeX.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet mentions 'trouble in Iran', which indicates a negative situation or event occurring there. The use of the word 'trouble' suggests concern or distress about the current state of affairs in Iran. Additionally, the hashtag '#flockofseagullsweregeopoliticallycorrect' seems to reference a song by Flock of Seagulls and adds a layer of irony or sarcasm, possibly implying that geopolitical correctness is being questioned or mocked. Overall, the tweet conveys a sense of unease about Iran's situation combined with some skepticism towards certain political stances.",
+        "sentiment": "negative",
+        "tweet": "Trouble in Iran, I see. Hmm. Iran. Iran so far away. #flockofseagullsweregeopoliticallycorrect",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user expresses feelings of fear ('terrifying') and sadness ('incredibly sad'), which are both negative emotions.",
+        "sentiment": "negative",
+        "tweet": "Reading the tweets coming out of Iran... The whole thing is terrifying and incredibly sad...",
+        "ground_truth": "negative"
+    }
+]

--- a/datasets/sentiment140/results/deepseek-r1-8b-prompts-results-20250209-072008.json
+++ b/datasets/sentiment140/results/deepseek-r1-8b-prompts-results-20250209-072008.json
@@ -1,0 +1,2156 @@
+[
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "@stellargirl I loooooooovvvvvveee my Kindle2. Not that the DX is cool, but the 2 is fantastic in its own right.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user mentions that they are reading their Kindle 2 and expresses a positive opinion about it, stating that Lee Childs books are a good read. The use of the word 'love' indicates strong positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "Reading my kindle2...  Love it... Lee childs is good read.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "Ok, first assesment of the #kindle2 ...it fucking rocks!!!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet starts with an @mention of 'kenburbary' which could be a username, indicating the speaker is addressing someone specific. The word 'love' conveys positive sentiment towards the Kindle2, suggesting satisfaction. Saying 'never looked back' implies that the user is happy and doesn't regret their purchase. The phrase 'The new big one is huge!' emphasizes positivity by highlighting the size as impressive without any negative qualifiers. Finally, using an exclamation mark after 'No need for remorse!' adds to the positive tone, showing confidence in their decision. Overall, all words and phrases used are positive or neutral but leaning heavily towards positive.",
+        "sentiment": "positive",
+        "tweet": "@kenburbary You'll love your Kindle2. I've had mine for a few months and never looked back. The new big one is huge! No need for remorse! :)",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user mentions having a Kindle2 and expresses satisfaction by saying 'I think it's perfect :)' which indicates positive feelings.",
+        "sentiment": "positive",
+        "tweet": "@mikefish  Fair enough. But i have the Kindle2 and I think it's perfect  :)",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "@richardebaker no. it is too big. I'm quite happy with the Kindle2.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expresses frustration towards AIG for not providing loans and uses strong language ('fuck this economy' and 'non loan given asses').",
+        "sentiment": "negative",
+        "tweet": "Fuck this economy. I hate aig and their non loan given asses.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user refers to jQuery as their 'new best friend,' which implies a positive relationship.",
+        "sentiment": "positive",
+        "tweet": "Jquery is my new best friend.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The term 'loves' indicates a positive emotion towards Twitter.",
+        "sentiment": "positive",
+        "tweet": "Loves twitter",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses admiration for Obama by questioning how someone couldn't love him, highlighting his humor.",
+        "sentiment": "positive",
+        "tweet": "how can you not love Obama? he makes jokes about himself.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "@Karoli I firmly believe that Obama/Pelosi have ZERO desire to be civil.  It's a charade and a slogan, but they want to destroy conservatism",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "House Correspondents dinner was last night whoopi, barbara &amp; sherri went, Obama got a standing ovation",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user mentions watching ESPN and refers to a new Nike commercial featuring a puppet version of LeBron James. They describe the commercial as 'hilarious' and use an exclamation mark, indicating strong positive emotions.",
+        "sentiment": "positive",
+        "tweet": "Watchin Espn..Jus seen this new Nike Commerical with a Puppet Lebron..sh*t was hilarious...LMAO!!!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet starts by addressing Nike directly, which shows frustration or disappointment. The phrase 'that shit is a waste of science' indicates strong dissatisfaction towards the product's innovation or technology used. Additionally, calling it 'ugly' further emphasizes negative feelings about both the functionality and aesthetics of the Flywire shoes.",
+        "sentiment": "negative",
+        "tweet": "dear nike, stop with the flywire. that shit is a waste of science. and ugly. love, @vincentx24x",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "#lebron best athlete of our generation, if not all time (basketball related) I don't want to get into inter-sport debates about   __1/2",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "I was talking to this guy last night and he was telling me that he is a die hard Spurs fan.  He also told me that he hates LeBron James.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet starts with a positive statement expressing affection for LeBron James.",
+        "sentiment": "positive",
+        "tweet": "i love lebron. http://bit.ly/PdHur",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "@ludajuice Lebron is a Beast, but I'm still cheering 4 the A..til the end.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "@Pmillzz lebron IS THE BOSS",
+        "sentiment": "positive",
+        "tweet": "@Pmillzz lebron IS THE BOSS",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user mentions 'I love the Lakers' which indicates a positive sentiment towards the team.",
+        "sentiment": "positive",
+        "tweet": "@sketchbug Lebron is a hometown hero to me, lol I love the Lakers but let's go Cavs, lol",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The phrase 'such an awesome duo' indicates a positive feeling towards LeBron James and Zydronas",
+        "sentiment": "positive",
+        "tweet": "lebron and zydrunas are such an awesome duo",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "@wordwhizkid Lebron is a beast... nobody in the NBA comes even close.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user mentions 'so much fun' which indicates a positive emotion.",
+        "sentiment": "positive",
+        "tweet": "downloading apps for my iphone! So much fun :-) There literally is an app for just about anything.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "good news, just had a call from the Visa office, saying everything is fine.....what a relief! I am sick of scams out there! Stealing!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "http://twurl.nl/epkr4b - awesome come back from @biz (via @fredwilson)",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet mentions a 'long weekend of R&amp;R' which stands for Relaxation and Recreation. The word 'Much needed' indicates that the person is looking forward to this break, suggesting positive feelings.",
+        "sentiment": "positive",
+        "tweet": "In montreal for a long weekend of R&amp;R. Much needed.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "Booz Allen Hamilton has a bad ass homegrown social collaboration platform. Way cool!  #ttiv",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "[#MLUC09] Customer Innovation Award Winner: Booz Allen Hamilton -- http://ping.fm/c2hPP",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "@SoChi2 I current use the Nikon D90 and love it, but not as much as the Canon 40D/50D. I chose the D90 for the  video feature. My mistake.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "@phyreman9 Google is always a good place to look. Should've mentioned I worked on the Mustang w/ my Dad, @KimbleT.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "Played with an android google phone. The slide out screen scares me I would break that fucker so fast. Still prefer my iPhone.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "US planning to resume the military tribunals at Guantanamo Bay... only this time those on trial will be AIG execs and Chrysler debt holders",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses frustration due to boredom and an uncomfortable sensation from itchy tattoos.",
+        "sentiment": "negative",
+        "tweet": "omg so bored &amp; my tattoooos are so itchy!!  help! aha =)",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a negative emotion by stating that the person feels itchy and miserable.",
+        "sentiment": "negative",
+        "tweet": "I'm itchy and miserable!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet uses a playful tone by mentioning 'itchy' and 'later, lol.' The word 'lol' indicates humor or light-heartedness.",
+        "sentiment": "positive",
+        "tweet": "@sekseemess no. I'm not itchy for now. Maybe later, lol.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "RT @jessverr I love the nerdy Stanford human biology videos - makes me miss school. http://bit.ly/13t7NR",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "@spinuzzi: Has been a bit crazy, with steep learning curve, but LyX is really good for long docs. For anything shorter, it would be insane.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet starts with a positive expression of enjoyment ('I'm listening to...'), followed by multiple 'Aww' and 'so amazing', which are strong indicators of positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "I'm listening to \"P.Y.T\" by Danny Gokey &lt;3 &lt;3 &lt;3 Aww, he's so amazing. I &lt;3 him so much :)",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet mentions that someone is going to sleep after a bike ride, which indicates they had an enjoyable experience.",
+        "sentiment": "positive",
+        "tweet": "is going to sleep then on a bike ride:]",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user mentions that they cannot sleep because their tooth is aching.",
+        "sentiment": "negative",
+        "tweet": "cant sleep... my tooth is aching.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet starts with a sense of frustration as it uses phrases like 'blah, blah' which convey negativity. The user mentions having no plans and is considering going back to sleep, indicating a lack of motivation or interest in the day's activities.",
+        "sentiment": "negative",
+        "tweet": "Blah, blah, blah same old same old. No plans today, going back to sleep I guess.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "glad i didnt do Bay to Breakers today, it's 1000 freaking degrees in San Francisco wtf",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "?Obama Administration Must Stop Bonuses to AIG Ponzi Schemers ... http://bit.ly/2CUIg",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "started to think that Citi is in really deep s&amp;^t. Are they gonna survive the turmoil or are they gonna be the next AIG?",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The term 'hate'n' suggests a negative emotion towards someone or something.",
+        "sentiment": "negative",
+        "tweet": "ShaunWoo hate'n on AiG",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet starts with an @mention of YarnThing, which is a positive engagement. The word 'awesome' is used positively to describe the experience of watching Star Trek.",
+        "sentiment": "positive",
+        "tweet": "@YarnThing you will not regret going to see Star Trek. It was AWESOME!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user is expressing frustration about a new trend where people are critically analyzing Michael Lewis and Malcolm Gladwell's work, which they find unnecessary or unwanted.",
+        "sentiment": "negative",
+        "tweet": "annoying new trend on the internets:  people picking apart michael lewis and malcolm gladwell.  nobody wants to read that.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "Highly recommend: http://tinyurl.com/HowDavidBeatsGoliath by Malcolm Gladwell",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet mentions 'Blink' by Malcolm Gladwell as an 'amazing book' which is a positive review.",
+        "sentiment": "positive",
+        "tweet": "Blink by malcolm gladwell amazing book and The tipping point!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "Malcolm Gladwell might be my new man crush",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expresses frustration towards ESPN's commercials saying they will 'drive them nuts.' This indicates a negative feeling about the content.",
+        "sentiment": "negative",
+        "tweet": "omg. The commercials alone on ESPN are going to drive me nuts.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet mentions that working with Twitter API is enjoyable, indicating positive feelings about the activity.",
+        "sentiment": "positive",
+        "tweet": "@robmalon Playing with Twitter API sounds fun.  May need to take a class or find a new friend who like to generate results with API code.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet contains a smiley face emoji ':)', which typically indicates a positive emotion.",
+        "sentiment": "positive",
+        "tweet": "Hello Twitter API ;)",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user mentions that Twitter API is slow and clients are not good, which indicates dissatisfaction.",
+        "sentiment": "negative",
+        "tweet": "@morind45 Because the twitter api is slow and most client's aren't good.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user mentions that Yahoo Answers can be frustrating at times.",
+        "sentiment": "negative",
+        "tweet": "yahoo answers can be a butt sometimes",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The use of a smiley face ':D' indicates a positive emotion.",
+        "sentiment": "positive",
+        "tweet": "is scrapbooking with Nic =D",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "RT @mashable: Five Things Wolfram Alpha Does Better (And Vastly Different) Than Google - http://bit.ly/6nSnR",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user has changed their profile picture to something related to sports, specifically basketball, which they find exciting.",
+        "sentiment": "positive",
+        "tweet": "just changed my default pic to a Nike basketball cause bball is awesome!!!!!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet mentions a layoff at Nike, which typically has a negative connotation as it affects employees' jobs and can lead to stress and uncertainty.",
+        "sentiment": "negative",
+        "tweet": "RT @SmartChickPDX: Was just told that Nike layoffs started today :-(",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The use of an exclamation mark indicates a positive tone.",
+        "sentiment": "positive",
+        "tweet": "Back when I worked for Nike we had one fav word : JUST DO IT! :)",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "By the way, I'm totally inspired by this freaky Nike commercial: http://snurl.com/icgj9",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user mentions that a product (the 50d) is supposed to arrive today, which indicates anticipation and positivity.",
+        "sentiment": "positive",
+        "tweet": "Class... The 50d is supposed to come today :)",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The exclamation mark indicates a sense of urgency or frustration.",
+        "sentiment": "negative",
+        "tweet": "needs someone to explain lambda calculus to him! :(",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "Took the Graduate Field Exam for Computer Science today.  Nothing makes you feel like more of an idiot than lambda calculus.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "SHOUT OUTS TO ALL EAST PALO ALTO FOR BEING IN THE BUILDIN KARIZMAKAZE 50CAL GTA! ALSO THANKS TO PROFITS OF DOOM UNIVERSAL HEMPZ CRACKA......",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "@legalgeekery Yeahhhhhhhhh, I wouldn't really have lived in East Palo Alto if I could have avoided it.  I guess it's only for the summer.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet starts by mentioning two accounts, @accannis and @edog1203, which could be other users or entities related to the course. The user then expresses gratitude towards them for making a Stanford course available publicly. They describe the course as 'really helpful and informative,' which are positive adjectives indicating satisfaction with the content.",
+        "sentiment": "positive",
+        "tweet": "@accannis @edog1203 Great Stanford course. Thanks for making it available to the public! Really helpful and informative for starting off!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet includes an exclamation mark '!!!' which typically indicates excitement or enthusiasm.",
+        "sentiment": "positive",
+        "tweet": "@ work til 6pm... lets go lakers!!!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet uses an expletive ('Damn') which typically indicates a strong negative emotion.",
+        "sentiment": "negative",
+        "tweet": "Damn you North Korea. http://bit.ly/KtMeQ",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a desire to eliminate North Korea, which is a serious statement indicating strong negative feelings towards that country.",
+        "sentiment": "negative",
+        "tweet": "Can we just go ahead and blow North Korea off the map already?",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet uses derogatory language such as 'douchebaggery' to describe North Korea's actions, which is a strong negative term. The phrase 'China doesn't even like you anymore' further indicates that there is disapproval and negativity towards both parties involved.",
+        "sentiment": "negative",
+        "tweet": "North Korea, please cease this douchebaggery. China doesn't even like you anymore. http://bit.ly/NeHSl",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "Why the hell is Pelosi in freakin China? and on whose dime?",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "Are YOU burning more cash $$$ than Chrysler and GM? Stop the financial tsunami. Where \"bailout\" means taking a handout!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user mentions that insects have infected their spinach plant, which indicates a problem or issue they are facing.",
+        "sentiment": "negative",
+        "tweet": "insects have infected my spinach plant :(",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "wish i could catch every mosquito in the world n burn em slowly.they been bitin the shit outta me 2day.mosquitos are the assholes of insects",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet mentions a dislike for insects without any indication of positivity.",
+        "sentiment": "negative",
+        "tweet": "just got back from church, and I totally hate insects.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet starts with a negative comment about McDonald's, specifically mentioning that the eggs made them feel sick. This is clearly a negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "Just got mcdonalds goddam those eggs make me sick. O yeah Laker up date go lakers. Not much of an update? Well it's true so suck it",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet contains words like 'ohhdee' which expresses excitement, and mentions wanting McDonald's, indicating a positive interest. The use of 'lol' suggests humor or light-heartedness.",
+        "sentiment": "positive",
+        "tweet": "omgg i ohhdee want mcdonalds damn i wonder if its open lol =]",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet contains a word that expresses frustration or dissatisfaction, such as 'ugh'. This indicates a negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "History exam studying ugh",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "I hate revision, it's so boring! I am totally unprepared for my exam tomorrow :( Things are not looking good...",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user mentions a higher physics exam tomorrow and expresses a lack of enthusiasm saying 'not lookin forward to it much :('. The use of an emoji with a sad face indicates negative feelings. Words like 'not lookin forward' also convey negativity.",
+        "sentiment": "negative",
+        "tweet": "Higher physics exam tommorow, not lookin forward to it much :(",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "It's a bank holiday, yet I'm only out of work now. Exam season sucks:(",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "Cheney and Bush are the real culprits - http://fwix.com/article/939496",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "Life?s a bitch? and so is Dick Cheney. #p2 #bipart #tlot #tcot #hhrs #GOP #DNC http://is.gd/DjyQ",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "Dick Cheney's dishonest speech about torture, terror, and Obama. -Fred Kaplan Slate. http://is.gd/DiHg",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "\"The Republican party is a bunch of anti-abortion zealots who couldn't draw flies to a dump.\" -- Neal Boortz (just now, on the radio)",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "is Twitter's connections API broken? Some tweets didn't make it to Twitter...",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user expresses frustration towards Twitter's API timeouts, using strong language like 'hate' and 'annoying.' The exclamation marks indicate a high level of emotion. These elements contribute to a negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "i srsly hate the stupid twitter API timeout thing, soooo annoying!!!!! :(",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "@psychemedia I really liked @kswedberg's \"Learning jQuery\" book. http://bit.ly/pg0lT is worth a look too",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "Very Interesting Ad from Adobe by Goodby, Silverstein &amp; Partners - YouTube - Adobe CS4: Le Sens Propre http://bit.ly/VprpT",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "Goodby Silverstein agency new site! http://www.goodbysilverstein.com/ Great!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet starts by retweeting a post from @designplay about Goodby, Silverstein's new website. The user then expresses their enjoyment of the site with 'I enjoy it.' They also uses the term '*nice find!*' which is positive language indicating approval and satisfaction.",
+        "sentiment": "positive",
+        "tweet": "RT @designplay Goodby, Silverstein's new site: http://www.goodbysilverstein.com/ I enjoy it. *nice find!*",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet starts by praising Psyop and Goodby Silverstein &amp; Partners, using words like 'ever amazing' which indicates a positive sentiment. The mention of 'have to go play with After Effects now' suggests excitement or eagerness, further contributing to a positive tone.",
+        "sentiment": "positive",
+        "tweet": "The ever amazing Psyop and Goodby Silverstein &amp; Partners for HP! http://bit.ly/g2rU8 Have to go play with After Effects now!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "top ten most watched on Viral-Video Chart.  Love the nike #mostvaluablepuppets campaign from Wieden &amp; Kennedy http://bit.ly/nR1n9",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The exclamation marks indicate strong emotions, suggesting excitement.",
+        "sentiment": "positive",
+        "tweet": "zomg!!! I have a G2!!!!!!!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet mentions 'lots of buzz' which is positive, indicating excitement. However, it also says 'how lucky are they - a Free G2!!', suggesting that the recipient feels fortunate or privileged to receive something valuable.",
+        "sentiment": "positive",
+        "tweet": "Ok so lots of buzz from IO2009 but how lucky are they - a Free G2!! http://is.gd/Hyzl",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user received a free G2 Android device at Google I/O, which is a significant event that typically generates excitement.",
+        "sentiment": "positive",
+        "tweet": "just got a free G2 android at google i/o!!!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "Guess I'll be retiring my G1 and start using my developer G2 woot #googleio",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expresses happiness about Philip's presence at Google IO, indicating a positive event.",
+        "sentiment": "positive",
+        "tweet": "I am happy for Philip being at GoogleIO today",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "Lakers played great!  Cannot wait for Thursday night Lakers vs. ???",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "Judd Apatow creates fake sitcom on NBC.com to market his new movie... viral marketing at its best. http://is.gd/K0yK",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "VIRAL MARKETING FAIL. This Acia Pills brand oughta get shut down for hacking into people's messenger's.  i get 5-6 msgs in a day! Arrrgh!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user mentions 'Night at The Museum' which is a popular movie. They respond with 'Lmao', which typically indicates laughter or amusement.",
+        "sentiment": "positive",
+        "tweet": "watching Night at The Museum . Lmao",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expresses excitement and joy about their experience at Night at the Museum.",
+        "sentiment": "positive",
+        "tweet": "i loved night at the museum!!!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet mentions that they enjoyed watching a movie, which is typically an enjoyable activity.",
+        "sentiment": "positive",
+        "tweet": "just got back from the movies.  went to see the new night at the museum with rachel.  it was good",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "@shannyoday I will take you on a date to see night at the museum 2 whenever you want...it looks soooooo good",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user mentions not watching a movie called 'The Night At The Museum.' They describe it as getting really good, which is a positive statement about the quality of the movie.",
+        "sentiment": "positive",
+        "tweet": "no watching The Night At The Museum. Getting Really Good",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet mentions a fun activity ('Night at the Museum') and references something positive like 'junk food' which is often associated with enjoyment or indulgence. The phrase 'perfect monday!' indicates overall satisfaction.",
+        "sentiment": "positive",
+        "tweet": "Night at the Museum, Wolverine and junk food - perfect monday!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "saw night at the museum 2 last night.. pretty crazy movie.. but the cast was awesome so it was well worth it. Robin Williams forever!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user mentions a change from watching 'UP' to 'Night at the Museum,' which suggests they are not as enthusiastic about the new choice.",
+        "sentiment": "negative",
+        "tweet": "Night at the Museum tonite instead of UP. :( oh well. that 4 yr old better enjoy it. LOL",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "It's unfortunate that after the Stimulus plan was put in place twice to help GM on the back of the American people has led to the inevitable",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "Tell me again why we are giving more $$ to GM?? We should use that $ for all the programs that support the unemployed.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet mentions that General Motors (GM) might die, which could lead to increased value as people scramble for the remaining stock. The phrase 'boo hahaha' suggests a sense of humor or sarcasm about the situation.",
+        "sentiment": "positive",
+        "tweet": "@jdreiss oh yes but if GM dies it will only be worth more boo hahaha",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "Time Warner cable is down again 3rd time since Memorial Day bummer!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "I would rather pay reasonable yearly taxes for \"free\" fast internet, than get gouged by Time Warner for a slow connection.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "NOOOOOOO my DVR just died and I was only half way through the EA presser. Hate you Time Warner",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet uses multiple expletives ('F*ck', 'suck balls') and calls the company names like 'Time Warner Cable' with an asterisk, indicating frustration. The user mentions spending $700 on a TV but still having issues with HD channels not working properly. They describe this as 'bullshit,' which shows strong negative feelings about their experience.",
+        "sentiment": "negative",
+        "tweet": "F*ck Time Warner Cable!!! You f*cking suck balls!!! I have a $700 HD tv &amp; my damn HD channels hardly ever come in. Bullshit!!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "time warner has the worse customer service ever. I will never use them again",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "Time warner is the devil. Worst possible time for the Internet to go out.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet contains strong language ('fuck') which indicates a negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "Fuck no internet damn time warner!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "time warner really picks the worst time to not work. all i want to do is get to mtv.com so i can watch the hills. wtfffff.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "I hate Time Warner! Soooo wish I had Vios. Cant watch the fricken Mets game w/o buffering. I feel like im watching free internet porn.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "Ahh...got rid of stupid time warner today &amp; now taking a nap while the roomies cook for me. Pretty good end for a monday :)",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user describes Time Warner's HD lineup as 'crap,' which is a strong negative term indicating dissatisfaction.",
+        "sentiment": "negative",
+        "tweet": "Time Warner's HD line up is crap.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "is being fucked by time warner cable. didnt know modems could explode. and Susan Boyle sucks too!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "Time Warner Cable slogan: Where calling it a day at 2pm Happens.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet mentions recovery from surgery, which can be physically and emotionally challenging. The user expresses a wish that @julesrenner were present to assist or provide support, indicating a desire for help or company during this difficult time.",
+        "sentiment": "negative",
+        "tweet": "Recovering from surgery..wishing @julesrenner was here :(",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "My wrist still hurts. I have to get it looked at. I HATE the dr/dentist/scary places. :( Time to watch Eagle eye. If you want to join, txt!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "THE DENTIST LIED! \" U WON'T FEEL ANY DISCOMORT! PROB WON'T EVEN NEED PAIN PILLS\" MAN U TWIPPIN THIS SHIT HURT!! HOW MANY PILLS CAN I TAKE!!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "@kirstiealley my dentist is great but she's expensive...=(",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet contains two separate activities mentioned by the user: studying math and going to the dentist. The word 'studying' is associated with academic success, which typically has a positive connotation. However, the mention of a dental appointment could be seen as an unpleasant or unavoidable task.",
+        "sentiment": "negative",
+        "tweet": "is studing math ;) tomorrow exam and dentist :)",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "my dentist was wrong... WRONG",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet mentions going to the dentist, which can be seen as a routine task that people often find necessary but may not look forward to.",
+        "sentiment": "negative",
+        "tweet": "Going to the dentist later.:|",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses frustration about car shopping, comparing it unfavorably to going to the dentist.",
+        "sentiment": "negative",
+        "tweet": "Son has me looking at cars online.  I hate car shopping.  Would rather go to the dentist!  Anyone with a good car at a good price to sell?",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet describes an uncomfortable situation where the individuals were stopped by someone, possibly a security guard or law enforcement officer, who made them empty their pockets and lift their shirts. This indicates potential suspicion or concern about them. The use of words like 'jacked up' suggests frustration or anger at being subjected to such an encounter without clear justification.",
+        "sentiment": "negative",
+        "tweet": "luke and i got stopped walking out of safeway and asked to empty our pockets and lift our shirts. how jacked up is that?",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The term 'rock n roll' typically has a positive connotation associated with music and rebellion, which can evoke feelings of excitement and energy.",
+        "sentiment": "positive",
+        "tweet": "Safeway is very rock n roll tonight",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user mentions that the Safeway bathroom has a foul odor, which is described as 'smells like ass.' This phrase is clearly negative and conveys dissatisfaction with the condition of the bathroom.",
+        "sentiment": "negative",
+        "tweet": "The safeway bathroom still smells like ass!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet mentions that people at Safeway on Elkhorn are moving as if they're dead.",
+        "sentiment": "negative",
+        "tweet": "At safeway on elkhorn, they move like they're dead!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "i love Dwight Howard's vitamin water commercial... now i wish he was with NIKE and not adidas. lol.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "Found NOTHING at Nike Factory :/ Off to Banana Republic Outlet! http://myloc.me/2zic",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "is lovin his Nike  already and that's only from running on the spot in his bedroom",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user mentions 'Yay' which is a common expression of positivity, indicating happiness about their achievement.",
+        "sentiment": "positive",
+        "tweet": "@matthewcyan I finally got around to using jquery to make my bio collapse. Yay for slide animations.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet includes an exclamation mark and 'LOL' which are common indicators of positive emotion.",
+        "sentiment": "positive",
+        "tweet": "@PDubyaD right!!! LOL we'll get there!! I have high expectations, Warren Buffet style.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet is a retweet of another user's content. The original tweet mentions planting trees and the impact it has over time, which can be seen as positive.",
+        "sentiment": "positive",
+        "tweet": "RT @blknprecious1: RT GREAT @dbroos \"Someone's sitting in the shade today because someone planted a tree a long time ago.\"- Warren Buffet",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "Warren Buffet became (for a time) the richest man in the United States, not by working but investing in 1 Big idea which lead to the fortune",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user mentions creating a school in NCAA 10 with Notre Dame having 7 receivers rated at 84 or higher. The use of 'create' and the smiley face emoji suggests excitement about this achievement.",
+        "sentiment": "positive",
+        "tweet": "According to the create a school, Notre Dame will have 7 receivers in NCAA 10 at 84 or higher rating :) *sweet*",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "@BlondeBroad it's definitely under warranty &amp; my experience is the amazon support for kindle is great! had to contact them about my kindle2",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "Time Warner Road Runner customer support here absolutely blows. I hate not having other high-speed net options. I'm ready to go nuclear.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "Time Warner cable phone reps r dumber than nails!!!!! UGH! Cable was working 10 mins ago now its not WTF!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The use of a smiley face at the end indicates a positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "@siratomofbones we tried but Time Warner wasn't being nice so we recorded today. :)",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet starts with an exclamation and a strong swear word, indicating frustration. The user mentions that their internet installation was delayed from today to next Saturday, which means they will be without internet for another week. This delay is described as 'f'ed up,' further showing the user's dissatisfaction. Additionally, the use of multiple hashtags and symbols does not add positive sentiment but rather emphasizes the frustration.",
+        "sentiment": "negative",
+        "tweet": "OMG - time warner f'ed up my internet install - instead of today  its now NEXT saturday - another week w/o internet! &amp;$*ehfa^V9fhg[*# fml.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "wth..i have never seen a line this loooong at time warner before, ugh.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "Impatiently awaiting the arrival of the time warner guy. It's way too pretty to be inside all afternoon",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The term 'naive bayes' refers to a machine learning algorithm commonly used for text classification. However, the user mentions that they are using it with 'EM', which stands for Expectation-Maximization, an extension of the EM algorithm typically used in clustering problems. This combination might lead to complexities or unexpected results, causing frustration.",
+        "sentiment": "negative",
+        "tweet": "Naive Bayes using EM for Text Classification. Really Frustrating...",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "We went to Stanford University today. Got a tour. Made me want to go back to college. It's also decided all of our kids will go there.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "@KarrisFoxy If you're being harassed by calls about your car warranty, changing your number won't fix that. They call every number. #d-bags",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "Just blocked United Blood Services using Google Voice. They call more than those Car Warranty guys.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "#at&amp; t is a company known for its services like internet and DirecTV. The user refers to it as 'complete fail,' which means they are dissatisfied with their service. Words like 'fail' indicate negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "#at&amp;t is complete fail.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet uses an exclamation mark and a slang term 'OH SNAP' which typically indicates surprise or excitement, suggesting positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "@broskiii OH SNAP YOU WORK AT AT&amp;T DON'T YOU",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "@Mbjthegreat i really dont want AT&amp;T phone service..they suck when it comes to having a signal",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "I say we just cut out the small talk: AT&amp;T's new slogan: F__k you, give us your money. (Apologies to Bob Geldof.)",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "pissed about at&amp;t's mid-contract upgrade price for the iPhone (it's $200 more) I'm not going to pay $499 for something I thought was $299",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user mentions Safari 4 being fast, which is a positive aspect. However, they also refer to their internet connection as 'shitty,' which indicates dissatisfaction with the service.",
+        "sentiment": "negative",
+        "tweet": "Safari 4 is fast :) Even on my shitty AT&amp;T tethering.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "@ims What is AT&T ...",
+        "sentiment": "negative",
+        "tweet": "@ims What is AT&amp;T fucking up?",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "@springsingfiend @dvyers @sethdaggett @jlshack AT&amp;T dropped the ball and isn't supporting crap with the new iPhone 3.0... FAIL #att SUCKS!!!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "@MMBarnhill yay, glad you got the phone! Still, damn you, AT&amp;T.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "Talk is Cheap: Bing that, I?ll stick with Google. http://bit.ly/XC3C8",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user is expressing frustration about Twitter's handling of deleted tweets. They mention that even after deletion, tweets can still be found through Summarize and search functions, which suggests a lack of effectiveness in removing content. The phrase 'WTF is the point' indicates strong surprise or confusion, while 'please fix that' shows a desire for improvement. The overall tone reflects dissatisfaction with Twitter's current system.",
+        "sentiment": "negative",
+        "tweet": "@defsounds WTF is the point of deleting tweets if they can still be found in summize and searches? Twitter, please fix that. Thanks and bye",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet starts with @ArunBasilLal, addressing someone positively. The phrase 'I love Google Translator too!' indicates a positive sentiment towards the product. Ending with 'Good day mate!' is friendly and positive.",
+        "sentiment": "positive",
+        "tweet": "@ArunBasilLal I love Google Translator too ! :D Good day mate !",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user mentions a 'new Kindle2,' which indicates they recently acquired a new device. The term 'reading' suggests engagement in an enjoyable activity, such as leisurely reading.",
+        "sentiment": "positive",
+        "tweet": "reading on my new Kindle2!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expresses excitement about receiving their Kindle2, using an exclamation mark and a smiley face to convey enthusiasm.",
+        "sentiment": "positive",
+        "tweet": "My Kindle2 came and I LOVE it! :)",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "LOVING my new Kindle2.  Named her Kendra in case u were wondering. The \"cookbook\" is THE tool cuz it tells u all the tricks!  Best gift EVR!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "The real AIG scandal / http://bit.ly/b82Px",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user refers to Obama as a 'good comedian' and mentions that his dinner speech was 'very funny.' These are clear indicators of positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "Obama is quite a good comedian! check out his dinner speech on CNN :) very funny jokes.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet starts by mentioning that Barack Obama showed his 'funny side' which immediately conveys a positive tone. The use of the word 'Great' further emphasizes positivity, indicating satisfaction with something.",
+        "sentiment": "positive",
+        "tweet": "' Barack Obama shows his funny side \" &gt;&gt; http://tr.im/l0gY !! Great speech..",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "I like this guy : ' Barack Obama shows his funny side \" &gt;&gt; http://tr.im/l0gY !!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet starts with a positive adjective ('awesome') to describe Obama's speech, which immediately conveys a positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "Obama's speech was pretty awesome last night! http://bit.ly/IMXUM",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "Reading  \"Bill Clinton Fail - Obama Win?\" http://tinyurl.com/pcyxj7",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "Obama More Popular Than U.S. Among Arabs: Survey: President Barack Obama's popularity in leading Arab countries .. http://tinyurl.com/prlvqu",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user starts by expressing humor towards Obama, using 'jokes' and 'haha.' They also mention enjoying an after-dinner speech and being 'in love with Mr. President,' which indicates admiration.",
+        "sentiment": "positive",
+        "tweet": "Obama's got JOKES!! haha just got to watch a bit of his after dinner speech from last night... i'm in love with mr. president ;)",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "LEbron james got in a car accident i guess..just heard it on evening news...wow i cant believe it..will he be ok ? http://twtad.com/69750",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "is it me or is this the best the playoffs have been in years oh yea lebron and melo in the finals",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user directly states that LeBron James is the best without any qualifying statements.",
+        "sentiment": "positive",
+        "tweet": "@khalid0456 No, Lebron is the best",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet mentions that LeBron James has a 'cool' personality and notes that he has 'good character.' These are positive traits that contribute to a favorable impression.",
+        "sentiment": "positive",
+        "tweet": "@the_real_usher LeBron is cool.  I like his personality...he has good character.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The term 'nigga' is a highly offensive racial slur and demonstrates a lack of respect for others.",
+        "sentiment": "negative",
+        "tweet": "Watching Lebron highlights. Damn that niggas good",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "@Lou911 Lebron is MURDERING shit.",
+        "sentiment": "negative",
+        "tweet": "@Lou911 Lebron is MURDERING shit.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The term 'monsta' implies something impressive, suggesting positivity towards LeBron James.",
+        "sentiment": "positive",
+        "tweet": "@uscsports21 LeBron is a monsta and he is only 24. SMH The world ain't ready.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "@cthagod when Lebron is done in the NBA he will probably be greater than Kobe. Like u said Kobe is good but there alot of 'good' players.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expresses support for KOBE over LeBron by stating that KOBE is good and giving their vote to him.",
+        "sentiment": "positive",
+        "tweet": "KOBE IS GOOD BT LEBRON HAS MY VOTE",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user explicitly states that Kobe is better than LeBron, using strong language ('not'). This shows a clear preference for one over the other.",
+        "sentiment": "positive",
+        "tweet": "Kobe is the best in the world not lebron .",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "@asherroth World Cup 2010 Access?? Damn, that's a good look!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "Just bought my tickets for the 2010 FIFA World Cup in South Africa. Its going to be a great summer. http://bit.ly/9GEZI",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "I have to go to Booz Allen Hamilton for a 2hr meeting :(  But then i get to go home :)",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "The great Indian tamasha truly will unfold from May 16, the result day for Indian General Election.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet mentions that the user has a Kindle2 and expresses enthusiasm about their usage, stating they use it every day.",
+        "sentiment": "positive",
+        "tweet": "@crlane I have the Kindle2. I've seen pictures of the DX, but haven't seen it in person. I love my Kindle - I'm on it everyday.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "@criticalpath Such an awesome idea - the  continual learning program with a Kindle2  http://bit.ly/1ZLfF",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "@faithbabywear Ooooh, what model are you getting??? I have the 40D and LOVE LOVE LOVE LOVE it!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "The Times of India: The wonder that is India's election. http://bit.ly/p7u1H",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet mentions a good video from Google, which suggests a positive experience.",
+        "sentiment": "positive",
+        "tweet": "http://is.gd/ArUJ Good video from Google on using search options.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet starts with a humorous tone using 'lol' which indicates positivity. However, the user then complains about an itchy skin and mentions frustration from lawn mowing, which are negative sentiments.",
+        "sentiment": "negative",
+        "tweet": "@ambcharlesfield lol. Ah my skin is itchy :( damn lawnmowing.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses discomfort or irritation ('itchy back'), which conveys a negative emotion.",
+        "sentiment": "negative",
+        "tweet": "itchy back!! dont ya hate it!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "Stanford Charity Fashion Show a top draw http://cli.gs/NeNuAH",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "Stanford University?s Facebook Profile is One of the Most Popular Official University Pages - http://tinyurl.com/p5b3fl",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The term 'lyx' refers to a type of software used for LaTeX documents. The user describes it as 'cool,' which implies a positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "Lyx is cool.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "SOOO DISSAPOiNTED THEY SENT DANNY GOKEY HOME... YOU STiLL ROCK ...DANNY ... MY HOMETOWN HERO !! YEAH MiLROCKEE!!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "RT @PassionModel 'American Idol' fashion: Adam Lambert tones down, Danny Gokey cute ... http://cli.gs/7JWSHV",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet starts with @dannygokey, addressing someone by name which shows familiarity. The word 'I love you' indicates strong positive feelings towards Danny Gokey. The exclamation mark and smiley face further emphasize the positivity of the sentiment.",
+        "sentiment": "positive",
+        "tweet": "@dannygokey I love you DANNY GOKEY!! :)",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses feelings of exhaustion and lack of sleep.",
+        "sentiment": "negative",
+        "tweet": "so tired. i didn't sleep well at all last night.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet mentions a long flight ahead, which typically evokes a sense of discomfort or dissatisfaction.",
+        "sentiment": "negative",
+        "tweet": "Boarding plane for San Francisco in 1 hour; 6 hr flight. Blech.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet starts with a greeting to San Francisco, which is neutral. The next part mentions that their back hurts from the previous night, indicating discomfort or pain. Pain is typically associated with negative emotions such as distress or unhappiness.",
+        "sentiment": "negative",
+        "tweet": "bonjour San Francisco. My back hurts from last night..",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "With my best girl for a few more hours in San francisco. Mmmmmfamily is wonderful!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet uses a strong curse word ('f***') which indicates frustration or anger.",
+        "sentiment": "negative",
+        "tweet": "F*** up big, or go home - AIG",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user mentions that they went to see a Star Trek movie and found it very satisfying.",
+        "sentiment": "positive",
+        "tweet": "Went to see the Star Trek movie last night.  Very satisfying.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expresses excitement about attending a Star Trek event or movie.",
+        "sentiment": "positive",
+        "tweet": "I can't wait, going to see star trek tonight!!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user starts by stating that Star Trek was 'as good as everyone said.' This indicates a positive opinion about the show.",
+        "sentiment": "positive",
+        "tweet": "Star Trek was as good as everyone said!!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user mentions they are 'loving' a new Malcolm Gladwell book called Outliers, which indicates a positive interest.",
+        "sentiment": "positive",
+        "tweet": "am loving new malcolm gladwell book - outliers",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "I highly recommend Malcolm Gladwell's 'The Tipping Point.' My next audiobook will probably be one of his as well.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "Malcolm Gladwell is a genius at tricking people into not realizing he's a fucking idiot",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "@sportsguy33 hey no offense but malcolm gladwell is a pretenious, annoying cunt and he brings you down. cant read his shit",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet is a retweet from @clashmore, which suggests that they found the content valuable or interesting enough to share with their followers. The phrase 'Great article' indicates a positive sentiment towards the article written by Malcolm Gladwell.",
+        "sentiment": "positive",
+        "tweet": "RT @clashmore: http://bit.ly/SOYv7  Great article by Malcolm Gladwell.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expresses admiration for Malcolm Gladwell by stating that they \"seriously underestimated\" him, which indicates a high level of respect and appreciation.",
+        "sentiment": "positive",
+        "tweet": "I seriously underestimated Malcolm Gladwell.  I want to meet this dude.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "i hate comcast right now. everything is down cable internet &amp; phone....ughh what am i to do",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user explicitly states that Comcast sucks, which indicates a strong negative opinion about the company.",
+        "sentiment": "negative",
+        "tweet": "Comcast sucks.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "The day I never have to deal with Comcast again will rank as one of the best days of my life.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet mentions 'comcast' which is a company known for its cable services. The user is questioning if Comcast failed again, suggesting dissatisfaction with their service.",
+        "sentiment": "negative",
+        "tweet": "@Dommm did comcast fail again??",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The term 'Twitter API limit' suggests that there's a restriction on how much data can be accessed through Twitter's APIs, which could hinder someone's ability to perform certain tasks or gather information. The phrase 'curses the Twitter API limit' indicates frustration and inconvenience caused by this limitation.",
+        "sentiment": "negative",
+        "tweet": "curses the Twitter API limit",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user mentions that they now understand why Dave Winer complains about Twitter's API limitations and access throttling. This indicates a negative experience or frustration with the platform.",
+        "sentiment": "negative",
+        "tweet": "Now I can see why Dave Winer screams about lack of Twitter API, its limitations and access throttles!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user mentions that dealing with the Twitter API is causing them stress.",
+        "sentiment": "negative",
+        "tweet": "Arg. Twitter API is making me crazy.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "I'm really loving the new search site Wolfram/Alpha. Makes Google seem so ... quaint. http://www72.wolframalpha.com/",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user explicitly uses a profanity ('SUCKS') to describe Wolfram Alpha. This indicates strong negative sentiment towards the service.",
+        "sentiment": "negative",
+        "tweet": "#wolfram Alpha SUCKS! Even for researchers the information provided is less than you can get from #google or #wikipedia, totally useless!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet mentions visiting a Nike factory, which could indicate excitement about manufacturing processes or interest in products.",
+        "sentiment": "positive",
+        "tweet": "Off to the NIKE factory!!!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user mentions that new Nike Muppet commercials are 'pretty cute.' This is a positive descriptor, indicating enjoyment or approval of the content.",
+        "sentiment": "positive",
+        "tweet": "New nike muppet commercials are pretty cute. Why do we live together again?",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user starts by complimenting @Fraggle312's products, calling them 'awesome.' This is a positive indicator. However, the sentiment shifts when the user expresses disappointment that the products are owned by Nike, saying 'i so wish they weren't owned by nike :(' The use of an exclamation mark and negative language suggests dissatisfaction with this aspect.",
+        "sentiment": "negative",
+        "tweet": "@Fraggle312 oh those are awesome! i so wish they weren't owned by nike :(",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "@tonyhawk http://twitpic.com/5c7uj - AWESOME!!! Seeing the show Friday at the Shoreline Amphitheatre. Never seen NIN before. Can't wait. ...",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expresses frustration by using an exclamation mark and a sad emoji ('= =",
+        "sentiment": "negative",
+        "tweet": "arhh, It's weka bug. = =\" and I spent almost two hours to find that out. crappy me",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "@mitzs hey bud :) np I do so love my 50D, although I'd love a 5D mkII more",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user mentions getting a '50D' which is likely an upgrade or new equipment, indicating positive progress.",
+        "sentiment": "positive",
+        "tweet": "@jonduenas @robynlyn just got us a 50D for the office. :D",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "Just picked up my new Canon 50D...it's beautiful!!  Prepare for some seriously awesome photography!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expresses enthusiasm about receiving a new Canon 50D camera, using multiple 'love's to convey excitement.",
+        "sentiment": "positive",
+        "tweet": "Just got my new toy. Canon 50D. Love love love it!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user mentions their excitement about learning lambda calculus, using a smiley emoji to convey positivity.",
+        "sentiment": "positive",
+        "tweet": "Learning about lambda calculus :)",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user mentions moving to a specific location which could indicate excitement or a positive change.",
+        "sentiment": "positive",
+        "tweet": "I'm moving to East Palo Alto!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet starts with an @mention, which is common in social media interactions. The user expresses appreciation by saying they 'just finished watching' the class and 'really appreciate it.' These are positive words indicating gratitude. Additionally, calling someone a 'Rockstar' or using similar terms typically conveys admiration and respect.",
+        "sentiment": "positive",
+        "tweet": "@ atebits I just finished watching your Stanford iPhone Class session. I really appreciate it. You Rock!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet starts with a greeting, which is generally positive. The user mentions enjoying someone's talk at Stanford, which implies they found it valuable or interesting. They also mention that the videos have gotten around, suggesting popularity and reach.",
+        "sentiment": "positive",
+        "tweet": "@jktweet Hi! Just saw your Stanford talk and really liked your advice. Just saying Hi from Singapore (yes the videos do get around)",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet uses an exclamation mark to express excitement and includes a call to action for Lakers fans, indicating enthusiasm.",
+        "sentiment": "positive",
+        "tweet": "LAKERS tonight let's go!!!!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The phrase 'kick their ass' suggests a competitive and possibly aggressive tone.",
+        "sentiment": "negative",
+        "tweet": "Will the Lakers kick the Nuggets ass tonight?",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "Oooooooh... North Korea is in troubleeeee! http://bit.ly/19epAH",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "Wat the heck is North Korea doing!!??!! They just conducted powerful nuclear tests! Follow the link: http://www.msnbc.msn.com/id/30921379",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "Listening to Obama... Friggin North Korea...",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "I just realized we three monkeys in the white Obama.Biden,Pelosi . Sarah Palin 2012",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "@foxnews Pelosi should stay in China and never come back.",
+        "sentiment": "negative",
+        "tweet": "@foxnews Pelosi should stay in China and never come back.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "Nancy Pelosi gave the worst commencement speech I've ever heard. Yes I'm still bitter about this",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user expresses frustration towards insects that have been biting them, using words like 'ugh' and 'grr.' These are clear indicators of negative emotions.",
+        "sentiment": "negative",
+        "tweet": "ugh. the amount of times these stupid insects have bitten me. Grr..",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet uses an exclamation mark to express enthusiasm, calling them 'Prettiest insects EVER.' This indicates a positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "Prettiest insects EVER - Pink Katydids: http://bit.ly/2Upw2p",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet describes an encounter with a large group of insects, which are described as being 'hungry' and 'scary'. The use of words like 'barraged' and 'scary' conveys a sense of fear or alarm.",
+        "sentiment": "negative",
+        "tweet": "Just got barraged by a horde of insects hungry for my kitchen light. So scary.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user mentions having McDonald's for dinner, using a smiley face (:D) which indicates positive emotion.",
+        "sentiment": "positive",
+        "tweet": "Just had McDonalds for dinner. :D It was goooood. Big Mac Meal. ;)",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The use of emojis like :relieved: and laughter indicates a light-hearted tone.",
+        "sentiment": "positive",
+        "tweet": "AHH YES LOL IMA TELL MY HUBBY TO GO GET ME SUM MCDONALDS =]",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet mentions having lunch at McDonald's and expresses excitement about chicken nuggets, using words like 'yummmmmy' with multiple exclamation points.",
+        "sentiment": "positive",
+        "tweet": "Stopped to have lunch at McDonalds. Chicken Nuggetssss! :) yummmmmy.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses a strong desire for McDonald's food.",
+        "sentiment": "positive",
+        "tweet": "Could go for a lot of McDonalds. i mean A LOT.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet starts with a positive statement about an exam going well. The user mentions that their exam was successful, indicating satisfaction. Additionally, they acknowledge that someone's prayers worked out for them, which further conveys positivity and gratitude.",
+        "sentiment": "positive",
+        "tweet": "my exam went good. @HelloLeonie: your prayers worked (:",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user mentions being 'so happy' about having only one exam left, indicating a positive outlook on completing their studies.",
+        "sentiment": "positive",
+        "tweet": "Only one exam left, and i am so happy for it :D",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses concern about failing an exam related to math review.",
+        "sentiment": "negative",
+        "tweet": "Math review. Im going to fail the exam.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "Colin Powell rocked yesterday on CBS. Cheney needs to shut the hell up and go home.Powell is a man of Honor and served our country proudly",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The phrase 'obviously not siding with Cheney here' indicates a lack of agreement or support for Cheney's position, which reflects a negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "obviously not siding with Cheney here: http://bit.ly/19j2d",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "Absolutely hilarious!!! from @mashable:  http://bit.ly/bccWt",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "@mashable I never did thank you for including me in your Top 100 Twitter Authors! You Rock! (&amp; I New Wave :-D) http://bit.ly/EOrFV",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet starts by mentioning 'Awesome jQuery reference book', which is a positive term indicating satisfaction. The use of 'awesome' adds to the positivity. Additionally, it tags @shrop and includes a link with '#webdesign', suggesting engagement in web design community.",
+        "sentiment": "positive",
+        "tweet": "RT @shrop: Awesome JQuery reference book for Coda! http://www.macpeeps.com/coda/ #webdesign",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "I've been sending e-mails like crazy today to my contacts...does anyone have a contact at Goodby SIlverstein...I'd love to speak to them",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet mentions a new website for Goodby, Silverstein and states that they enjoy it.",
+        "sentiment": "positive",
+        "tweet": "Goodby, Silverstein's new site... http://www.goodbysilverstein.com/ I enjoy it.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "Wow everyone at the Google I/O conference got free G2's with a month of unlimited service",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet mentions receiving a 'free Google Android phone' which is clearly a positive event.",
+        "sentiment": "positive",
+        "tweet": "@vkerkez dood I got a free google android phone at the I/O conference. The G2!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user mentions 'the G2 is amazing' which indicates a positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "@Orli the G2 is amazing btw, a HUGE improvement over the G1",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "HTML 5 Demos! Lots of great stuff to come! Yes, I'm excited. :) http://htmlfive.appspot.com #io2009 #googleio",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "@googleio http://twitpic.com/62shi - Yay! Happy place! Place place!  I love Google!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "#GoogleIO | O3D - Bringing 3d graphics to the browser. Very nice tbh. Funfun.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "Awesome viral marketing for \"Funny People\" http://www.nbc.com/yo-teach/",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses frustration about attending a movie due to desperation, indicating dissatisfaction.",
+        "sentiment": "negative",
+        "tweet": "saw night at the museum out of sheer desperation. who is funding these movies?",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user uses a colloquial expression ('furkin good') which indicates a positive sentiment.",
+        "sentiment": "positive",
+        "tweet": "Night At The Museum 2? Pretty furkin good.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user mentions 'giggling' which indicates a positive emotional response.",
+        "sentiment": "positive",
+        "tweet": "Watching Night at the Museum - giggling.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user mentions both movies positively by using exclamation marks. They describe 'Star Trek' as amazing and give a more neutral review of 'Night at the Museum,' saying it was ';eh.' However, since they are sharing their experiences with enthusiasm about one movie and neutrally about another, the overall sentiment leans positive.",
+        "sentiment": "positive",
+        "tweet": "Back from seeing 'Star Trek' and 'Night at the Museum.' 'Star Trek' was amazing, but 'Night at the Museum' was; eh.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user mentions 'night at the museum 2!' which refers to a movie known for its humor and family-friendly content.",
+        "sentiment": "positive",
+        "tweet": "just watched night at the museum 2! so stinkin cute!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "So, Night at the Museum 2 was AWESOME! Much better than part 1. Next weekend we'll see Up.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "saw the new Night at the Museum and i loved it. Next is to go see UP in 3D",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet expresses concern over General Motors' business decisions, questioning their ability to produce vehicles that meet the White House's expectations.",
+        "sentiment": "negative",
+        "tweet": "It is a shame about GM. What if they are forced to make only cars the White House THINKS will sell? What do you think?",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "As u may have noticed, not too happy about the GM situation, nor AIG, Lehman, et al",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet mentions 'good riddance' which typically has a negative connotation, indicating that something is being removed or discarded.",
+        "sentiment": "negative",
+        "tweet": "@Pittstock $GM good riddance.  sad though.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "I Will NEVER Buy a Government Motors Vehicle: Until just recently, I drove GM cars. Since 1988, when I bought a .. http://tinyurl.com/lulsw8",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "Having the old Coca-Cola guy on the GM board is stupid has heck! #tcot #ala",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "#RantsAndRaves The worst thing about GM (concord / pleasant hill / martinez): is the fucking UAW. ..   http://buzzup.com/4ueb",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "Give a man a fish, u feed him for the day. Teach him to fish, u feed him for life. Buy him GM, and u F**K him over for good.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "The more I hear about this GM thing the more angry I get. Billions wasted, more bullshit. All for something like 40k employees and all the..",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "@QuantTrader i own a GM car and it is junk as far as quality compared to a honda",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet mentions 'sad day...bankrupt GM' which indicates a negative perspective on General Motors.",
+        "sentiment": "negative",
+        "tweet": "sad day...bankrupt GM",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user mentions being 'upset' which indicates a negative emotion.",
+        "sentiment": "negative",
+        "tweet": "is upset about the whole GM thing. life as i know it is so screwed up",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet uses highly offensive language, including threats against an individual ('repeatedly raped') and compares it to being attacked by a rhino. Such extreme violence is unacceptable and indicates frustration with 'shitty cable svcs.' The use of explicit imagery suggests strong negative feelings about the subject.",
+        "sentiment": "negative",
+        "tweet": "whoever is running time warner needs to be repeatedly raped by a rhino so they understand the consequences of putting out shitty cable svcs",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "#WFTB Joining a bit late. My connection was down (boo time warner)",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user is comparing two cable providers, Cox and Time Warner (TW). They mention that Cox is cheaper and receives a better rating of 'B' from DSLReports, while Time Warner is more expensive with a lower rating of 'C'. The comparison suggests that Cox is the superior option in terms of cost-effectiveness and quality. There are no negative words used; instead, the tone highlights the advantages of one service over another without any criticism or dissatisfaction.",
+        "sentiment": "positive",
+        "tweet": "Cox or Time Warner?  Cox is cheaper and gets a B on dslreports.  TW is more expensive and gets a C.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user expresses strong negative emotions towards Time Warner's phone promotions.",
+        "sentiment": "negative",
+        "tweet": "i am furious with time warner and their phone promotions!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user mentions Chick-fil-a, which is a popular fast-food restaurant that generally has positive associations. However, they express frustration about their internet service being down, referring to Time Warner as 'stupid.' The term 'Damn' adds a negative tone. While the main topic of the tweet is about food and time spent with friends, the negative sentiment towards Time Warner overshadows the positive aspects.",
+        "sentiment": "negative",
+        "tweet": "Just got home from chick-fil-a with the boys. Damn my internets down =( stupid time warner",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user is expressing frustration towards Time-Warner Cable by questioning if it could get worse, implying dissatisfaction.",
+        "sentiment": "negative",
+        "tweet": "could time-warner cable suck more?  NO.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user expresses frustration towards Time Warner regarding their slow internet service.",
+        "sentiment": "negative",
+        "tweet": "Pissed at Time Warner for causin me to have slow internet problems",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet starts with an @mention indicating a conversation between two people. The user is asking if 'sportsguy33' has issues with Time Warner. This could imply that the person being mentioned might be facing some trouble or dissatisfaction with their service.",
+        "sentiment": "negative",
+        "tweet": "@sportsguy33 Ummm, having some Time Warner problems?",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet uses a very strong, vulgar expression ('suck so much ass') which is clearly negative in nature.",
+        "sentiment": "negative",
+        "tweet": "You guys see this?  Why does Time Warner have to suck so much ass?  Really wish I could get U-Verse at my apartment. http://bit.ly/s594j",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "RT @sportsguy33 The upside to Time Warner: unhelpful phone operators   superslow on-site service. Crap, that's not an upside.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "RT @sportsguy33: New Time Warner slogan: \"Time Warner, where we make you long for the days before cable.\"",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "confirmed: it's Time Warner's fault, not Facebook's, that fb is taking about 3 minutes to load. so tempted to switch to verizon =/",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The term 'epic fail' typically conveys a negative sentiment.",
+        "sentiment": "negative",
+        "tweet": "@sportsguy33 Time Warner = epic fail",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "I know. How sad is that?  RT @caseymercier: 1st day of hurricane season. That's less scarey than govt taking over GM.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "GM files Bankruptcy, not a good sign...",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet mentions that the Yankees have won and the Mets have lost, which indicates success for one team and failure for another.",
+        "sentiment": "positive",
+        "tweet": "yankees won mets lost. its a good day.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user mentions that their dental appointment was \"actually quite enjoyable,\" which indicates a positive experience.",
+        "sentiment": "positive",
+        "tweet": "My dentist appt today was actually quite enjoyable.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet uses strong language ('effing') which indicates a negative emotion towards dentists.",
+        "sentiment": "negative",
+        "tweet": "I hate the effing dentist.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet uses an exclamation mark and expresses a strong dislike for going to the dentist.",
+        "sentiment": "negative",
+        "tweet": "@kirstiealley I hate going to the dentist.. !!!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses a strong dislike for dentists, using an exclamation mark to emphasize frustration.",
+        "sentiment": "negative",
+        "tweet": "i hate the dentist....who invented them anyways?",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet mentions that the dentist's office is cold, which directly indicates a negative experience.",
+        "sentiment": "negative",
+        "tweet": "this dentist's office is cold :/",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet includes an exclamation mark and uses a happy emoji (:Y). These are indicators of positive emotion.",
+        "sentiment": "positive",
+        "tweet": "Just applied at Safeway!(: Yeeeee!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet mentions that 'Place is a nightmare right now' which indicates dissatisfaction, and 'Bumming' further conveys a negative mood.",
+        "sentiment": "negative",
+        "tweet": "@ Safeway. Place is a nightmare right now. Bumming.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user expresses frustration by calling it a 'waste of money' and uses an emotive expression '>_<'. These indicate negative feelings about the product.",
+        "sentiment": "negative",
+        "tweet": "HATE safeway select green tea icecream! bought two cartons, what a waste of money.  &gt;_&lt;",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet starts by expressing a positive opinion about Nike, using an exclamation mark and the word 'rocks' which indicates enthusiasm. The phrase 'I'm super grateful for what I've done with them :)' further reinforces this positivity as it conveys satisfaction and appreciation. Additionally, mentioning the European Division of NIKE as 'BEYOND!' uses another exclamation mark and a superlative adjective, highlighting their excellence in a positive light.",
+        "sentiment": "positive",
+        "tweet": "Nike rocks. I'm super grateful for what I've done with them :) &amp; the European Division of NIKE is BEYOND! @whitSTYLES @muchasmuertes",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet mentions 'addictive' which typically has a negative connotation, suggesting something that is difficult to stop or bad for one's well-being.",
+        "sentiment": "negative",
+        "tweet": "@evelynbyrne have you tried Nike  ? V. addictive.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user mentions that they find the app \"very interesting,\" which typically indicates a positive attitude towards it.",
+        "sentiment": "positive",
+        "tweet": "The Nike Training Club (beta) iPhone app looks very interesting.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expresses frustration by using an exclamation mark and multiple h's, indicating a strong emotional reaction.",
+        "sentiment": "negative",
+        "tweet": "argghhhh why won't  my jquery appear in safari bad safari !!!",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet starts by expressing a strong emotional connection to jQuery, using terms like 'forever in love' and 'marry it,' which are highly positive emotions. The humor comes from the pun on 'jquery.spokenFor.js,' implying that jQuery has been discussed or used extensively (as if someone had already claimed it). The phrase 'sorry ladies' adds a light-hearted, self-deprecating touch, suggesting the speaker is being playful rather than serious in their romantic intentions towards jQuery. Overall, despite the humorous and exaggerated language, the sentiment expressed is positive due to the genuine admiration and affection shown for jQuery.",
+        "sentiment": "positive",
+        "tweet": "I'm ready to drop the pretenses, I am forever in love with jQuery, and I want to marry it. Sorry ladies, this nerd is jquery.spokenFor.js",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "SUPER INVESTORS: A great weekend read here from Warren Buffet. Oldie, but a goodie. http://tinyurl.com/oqxgga",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "reading Michael Palin book, The Python Years...great book. I also recommend Warren Buffet &amp; Nelson Mandela's bio",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "I mean, I'm down with Notre Dame if I have to.  It's a good school, I'd be closer to Dan, I'd enjoy it.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "I can't watch TV without a Tivo.  And after all these years, the Time/Warner DVR  STILL sucks. http://www.davehitt.com/march03/twdvr.html",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "I'd say some sports writers are idiots for saying Roger Federer is one of the best ever in Tennis.  Roger Federer is THE best ever in Tennis",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "I still love my Kindle2 but reading The New York Times on it does not feel natural. I miss the Bloomingdale ads.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "I love my Kindle2. No more stacks of books to trip over on the way to the loo.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "Although today's keynote rocked, for every great announcement, AT&amp;T shit on us just a little bit more.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet starts by addressing someone named @sheridanmarfil and mentions an 'obsession' with cell phones in general, but then specifies that it's specifically the iPhone. The phrase 'I'm a slave to AT&T forever because of it' uses a metaphor implying frustration or dissatisfaction with the phone service provider due to the iPhone. However, the smiley face at the end suggests some level of humor or sarcasm rather than genuine anger.",
+        "sentiment": "negative",
+        "tweet": "@sheridanmarfil - its not so much my obsession with cell phones, but the iphone!  i'm a slave to at&amp;t forever because of it. :)",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "Fuzzball is more fun than AT&amp;T ;P http://fuzz-ball.com/twitter",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "Today is a good day to dislike AT&amp;T. Vote out of office indeed, @danielpunkass",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet starts with an exclamation point, indicating excitement. The user mentions receiving a Wave Sandbox invite and expresses eagerness to use it despite having class.",
+        "sentiment": "positive",
+        "tweet": "GOT MY WAVE SANDBOX INVITE! Extra excited! Too bad I have class now... but I'll play with it soon enough! #io2009 #wave",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user mentions that Summize has gone down, which indicates a decrease in performance or value.",
+        "sentiment": "negative",
+        "tweet": "looks like summize has gone down. too many tweets from WWDC perhaps?",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet starts with a thank you to @sklososky and mentions being a 'happy Kindle2 winner.' The word 'fabulous' indicates positive feelings about the experience. Overall, the tone is appreciative and enthusiastic.",
+        "sentiment": "positive",
+        "tweet": "@sklososky Thanks so much!!! ...from one of your *very* happy Kindle2 winners ; ) I was so surprised, fabulous. Thank you! Best, Kathleen",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "Man I kinda dislike Apple right now. Case in point: the iPhone 3GS. Wish there was a video recorder app. Please?? http://bit.ly/DZm1T",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet mentions that the user has two e-readers, the Kindle2 and the Sony PRS-500, both of which they like. They specifically praise the physical feel of the device, the readability of the font, and how quickly the page turns. However, they note that the UI feels a bit clunky.",
+        "sentiment": "positive",
+        "tweet": "@cwong08 I have a Kindle2 (&amp; Sony PRS-500). Like it! Physical device feels good. Font is nice. Pg turns are snappy enuf. UI a little klunky.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "The #Kindle2 seems the best eReader, but will it work in the UK and where can I get one?",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "I have a google addiction. Thank you for pointing that out, @annamartin123. Hahaha.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet uses derogatory language such as 'rich bastards' to address Google, indicating frustration or anger. The mention of the VISA card not working and being called out by name suggests that the user feels wronged or taken advantage of.",
+        "sentiment": "negative",
+        "tweet": "dearest @google, you rich bastards! the VISA card you sent me doesn't work. why screw a little guy like me?",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet expresses excitement for attending an event featuring two well-known chefs, indicating a positive anticipation.",
+        "sentiment": "positive",
+        "tweet": "Excited about seeing Bobby Flay and Guy Fieri tomorrow at the Great American Food &amp; Music Fest!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "Gonna go see Bobby Flay 2moro at Shoreline. Eat and drink. Gonna be good.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "can't wait for the great american food and music festival at shoreline tomorrow.  mmm...katz pastrami and bobby flay. yes please.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "My dad was in NY for a day, we ate at MESA grill last night and met Bobby Flay. So much fun, except I completely lost my voice today.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The tweet mentions 'Fighting with LaTeX' which implies a struggle or difficulty in using LaTeX.",
+        "sentiment": "negative",
+        "tweet": "Fighting with LaTex. Again...",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet starts by expressing strong affection for @Iheartseverus, using an exclamation mark which indicates enthusiasm. The phrase 'we love you too' reinforces this positive sentiment. However, the latter part of the tweet says 'don't want you to die!!!!!!', which is a concerning statement suggesting fear or anxiety about someone's well-being. Additionally, calling latex 'the devil' adds a negative connotation as it implies something evil or unpleasant.",
+        "sentiment": "negative",
+        "tweet": "@Iheartseverus we love you too and don't want you to die!!!!!!  Latex = the devil",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "7 hours. 7 hours of inkscape crashing, normally solid as a rock. 7 hours of LaTeX complaining at the slightest thing. I can't take any more.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The use of profanity like 'shit' indicates a negative attitude towards the situation.",
+        "sentiment": "negative",
+        "tweet": "Shit's hitting the fan in Iran...craziness indeed #iranelection",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet starts with Monday being mentioned, which could be neutral or slightly negative depending on context.",
+        "sentiment": "negative",
+        "tweet": "Monday already. Iran may implode. Kitchen is a disaster. @annagoss seems happy. @sebulous had a nice weekend and @goldpanda is great. whoop.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The tweet mentions testing burger recipes and references Bobby Flay's recipes, which are known for being high quality and popular.",
+        "sentiment": "positive",
+        "tweet": "getting ready to test out some burger receipes this weekend. Bobby Flay has some great receipes to try. Thanks Bobby.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "i lam so in love with Bobby Flay... he is my favorite. RT @terrysimpson: @bflay you need a place in Phoenix. We have great peppers here!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "I just created my first LaTeX file from scratch. That didn't work out very well. (See @amandabittner , it's a great time waster)",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user expresses a positive opinion about Linux, stating that it is 'so much nicer' than Windows. They also mention looking forward to using a LaTeX editor, which suggests they are excited or interested in enhancing their productivity with this tool.",
+        "sentiment": "positive",
+        "tweet": "using Linux and loving it - so much nicer than windows... Looking forward to using the wysiwyg latex editor!",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "The user expresses dissatisfaction with alternative typesetting systems for mathematics after having used LaTeX extensively.",
+        "sentiment": "negative",
+        "tweet": "After using LaTeX a lot, any other typeset mathematics just looks hideous.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "negative",
+        "tweet": "On that note, I hate Word. I hate Pages. I hate LaTeX. There, I said it. I hate LaTeX. All you TEXN3RDS can come kill me now.",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user expresses excitement about being back in a real text editing environment, using an emoticon to convey positive feelings.",
+        "sentiment": "positive",
+        "tweet": "Ahhh... back in a *real* text editing environment. I &lt;3 LaTeX.",
+        "ground_truth": "positive"
+    },
+    {
+        "reasoning": "...",
+        "sentiment": "positive",
+        "tweet": "Trouble in Iran, I see. Hmm. Iran. Iran so far away. #flockofseagullsweregeopoliticallycorrect",
+        "ground_truth": "negative"
+    },
+    {
+        "reasoning": "The user describes the situation as 'terrifying' and 'incredibly sad,' which are both strong negative terms.",
+        "sentiment": "negative",
+        "tweet": "Reading the tweets coming out of Iran... The whole thing is terrifying and incredibly sad...",
+        "ground_truth": "negative"
+    }
+]

--- a/propra_webscience_ws24/local_inference/deepseek.py
+++ b/propra_webscience_ws24/local_inference/deepseek.py
@@ -173,7 +173,8 @@ def save_results(results: list[EnrichedModelOutput]):
         results (list[EnrichedModelOutput]): The results to be saved.
     """
     with open(
-        f'{datetime.now().strftime("%Y%m%d-%H%M%S")}-{MODEL_NAME.lower()}-prompts-results.json',
+        f"{MODEL_NAME.replace(':', '-').lower()}-prompts-results-"
+        f'{datetime.now().strftime("%Y%m%d-%H%M%S")}.json',
         "w",
     ) as f:
         json.dump([result.model_dump() for result in results], f, indent=4)


### PR DESCRIPTION
Der Pull Request enthält eine kleine Anpassung in der `save_results` Funktion, damit die zero-shot Ausgaben auch im Verzeichnis gespeichert werden, welches wir bisher verwendet hatten.

Zusätzlich habe ich die Ausgaben der lokal aufgerufenen Modelle in den _JSON_ Dateien ergänzt.
Mit den Modellen 1.5B, 8B, 32B erhalte ich damit jeweils eine Genauigkeit von ~80%, ~85% und ~93%.

Übrigens: Die Ausgaben des größten Modells zur Einschätzung des Tweet-Inhalts ist teilweise interessant (insb. bei den Tweets, bei denen die Inference-Ausgabe von den Ground-Truth-Werten abweicht).